### PR TITLE
Removed ethernet inbox function pointer

### DIFF
--- a/Core/Inc/u_ethernet.h
+++ b/Core/Inc/u_ethernet.h
@@ -38,15 +38,12 @@ typedef struct {
 	uint8_t data[ETH_MESSAGE_SIZE];
 } ethernet_message_t;
 
-typedef void (*ethernet_inbox_function)(ethernet_message_t *message); /* Function to process received messages. */
-
 /**
  * @brief Initializes the NetX ethernet system in a repo. Inteded to be called from nx_app_thread_entry() in app_netxduo.c
  * @param node_id The ID (ethernet_node_t) of this node.
- * @param function The function to be called when a message is received. See the ethernet_inbox_function function prototype above.
  * @return Status.
  */
-uint8_t ethernet_init(ethernet_node_t node_id, ethernet_inbox_function function);
+uint8_t ethernet_init(ethernet_node_t node_id);
 
 /**
  * @brief Places an ethernet message in the outgoing queue (which will send the message).

--- a/Core/Src/u_ethernet.c
+++ b/Core/Src/u_ethernet.c
@@ -1,4 +1,5 @@
 #include "u_ethernet.h"
+#include "u_inbox.h"
 #include "nx_api.h"
 #include "nx_stm32_eth_driver.h"
 #include <string.h>
@@ -27,7 +28,6 @@ typedef struct {
     /* Device config variables */
 	bool                    is_initialized;
 	uint8_t                 node_id;
-    ethernet_inbox_function function; /* Function to process received messages. */
 } _ethernet_device_t;
 _ethernet_device_t device = {0};
 
@@ -134,7 +134,7 @@ static uint8_t _send_message(uint8_t message_id, ethernet_node_t recipient_id, u
 
 /* API FUNCTIONS */
 
-uint8_t ethernet_init(ethernet_node_t node_id, ethernet_inbox_function function) {
+uint8_t ethernet_init(ethernet_node_t node_id) {
     
     uint8_t status;
 
@@ -144,9 +144,8 @@ uint8_t ethernet_init(ethernet_node_t node_id, ethernet_inbox_function function)
         return U_ERROR;
     }
 
-    /* Store device info */
+    /* Store node id */
     device.node_id = node_id;
-    device.function = function;
 
     /* Create packet pool */
     status = nx_packet_pool_create(
@@ -311,7 +310,7 @@ uint8_t ethernet_process(void) {
 
     /* Process incoming messages */
     while(queue_receive(&eth_incoming, &message) == U_SUCCESS) {
-        device.function(&message);
+        ethernet_inbox(&message);
     }
 
     return U_SUCCESS;

--- a/NetXDuo/App/app_netxduo.c
+++ b/NetXDuo/App/app_netxduo.c
@@ -65,7 +65,7 @@ UINT MX_NetXDuo_Init(VOID *memory_ptr)
   /* USER CODE END App_NetXDuo_MEM_POOL */
   /* USER CODE BEGIN 0 */
 
-  return ethernet_init(VCU, ethernet_inbox);
+  ret = ethernet_init(VCU);
 
   /* USER CODE END 0 */
 


### PR DESCRIPTION
Removed function pointer for the ethernet inbox function, and replaced it with a direct call to ethernet_inbox()