### PR TITLE
Removed DEBUG_PRINT() message for when a queue is empty.

### DIFF
--- a/Core/Src/u_queues.c
+++ b/Core/Src/u_queues.c
@@ -127,7 +127,7 @@ uint8_t  queue_receive(queue_t *queue, void *message) {
 
     /* Receive message from the queue. */
     status = tx_queue_receive(&queue->_TX_QUEUE, buffer, QUEUE_WAIT_TIME);
-    if(status != TX_SUCCESS) {
+    if((status != TX_SUCCESS) || (status != TX_QUEUE_EMPTY)) {
         DEBUG_PRINT("ERROR: Failed to receive message from queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }


### PR DESCRIPTION
Title. Tiny small PR