### PR TITLE
Changed DEBUG_PRINT() to DEBUG_PRINTLN().

### DIFF
--- a/AZURE_RTOS/App/app_azure_rtos.c
+++ b/AZURE_RTOS/App/app_azure_rtos.c
@@ -87,7 +87,7 @@ VOID tx_application_define(VOID *first_unused_memory)
   if (tx_byte_pool_create(&tx_app_byte_pool, "Tx App memory pool", tx_byte_pool_buffer, TX_APP_MEM_POOL_SIZE) != TX_SUCCESS)
   {
     /* USER CODE BEGIN TX_Byte_Pool_Error */
-    DEBUG_PRINT("ERROR: Failed to create ThreadX byte pool.");
+    DEBUG_PRINTLN("ERROR: Failed to create ThreadX byte pool.");
     /* USER CODE END TX_Byte_Pool_Error */
   }
   else
@@ -101,7 +101,7 @@ VOID tx_application_define(VOID *first_unused_memory)
     if (status != TX_SUCCESS)
     {
       /* USER CODE BEGIN  App_ThreadX_Init_Error */
-      DEBUG_PRINT("ERROR: Failed to initialize ThreadX application (Status: %d).", status);
+      DEBUG_PRINTLN("ERROR: Failed to initialize ThreadX application (Status: %d).", status);
       while(1)
       {
         // fatal error so loop forever
@@ -117,7 +117,7 @@ VOID tx_application_define(VOID *first_unused_memory)
   if (tx_byte_pool_create(&nx_app_byte_pool, "Nx App memory pool", nx_byte_pool_buffer, NX_APP_MEM_POOL_SIZE) != TX_SUCCESS)
   {
     /* USER CODE BEGIN NX_Byte_Pool_Error */
-    DEBUG_PRINT("ERROR: Failed to create NetXDuo byte pool.");
+    DEBUG_PRINTLN("ERROR: Failed to create NetXDuo byte pool.");
     /* USER CODE END NX_Byte_Pool_Error */
   }
   else
@@ -131,7 +131,7 @@ VOID tx_application_define(VOID *first_unused_memory)
     if (status != NX_SUCCESS)
     {
       /* USER CODE BEGIN  MX_NetXDuo_Init_Error */
-      DEBUG_PRINT("ERROR: Failed to initialize NetXDuo application (Status: %d).", status);
+      DEBUG_PRINTLN("ERROR: Failed to initialize NetXDuo application (Status: %d).", status);
       while(1)
       {
         // fatal error so loop forever. unless we just don't want to use NetX/ethernet stuff.

--- a/Core/Inc/u_config.h
+++ b/Core/Inc/u_config.h
@@ -13,23 +13,23 @@
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__) /* Gets the name of the file. */
 #define U_DEBUG /* Comment out to enable/disable debugging. */
 #ifdef U_DEBUG
-    #define DEBUG_PRINT(message, ...) printf("[%s/%s()] " message "\n", __FILENAME__, __func__, ##__VA_ARGS__) /* Prints an error message in the format: "[file_name.c/function()] {message}"*/
+    #define DEBUG_PRINTLN(message, ...) printf("[%s/%s()] " message "\n", __FILENAME__, __func__, ##__VA_ARGS__) /* Prints an error message in the format: "[file_name.c/function()] {message}"*/
 #else
-    #define DEBUG_PRINT(message, ...) /* If debugging is turned off, macro doesn't need to expand to anything. */
+    #define DEBUG_PRINTLN(message, ...) /* If debugging is turned off, macro doesn't need to expand to anything. */
 #endif
 
 /**
- * @brief Checks if a function is successful when called. DEBUG_PRINTs an error message if it fails.
+ * @brief Checks if a function is successful when called. DEBUG_PRINTLNs an error message if it fails.
  * @param function_call The function to call.
  * @param success The function's success code/macro (e.g., U_SUCCESS, TX_SUCCESS, etc.).
  * 
  * @note This macro intentionally doesn't support custom error messages, for the sake of readability. If an error is complex enough to 
- *       require a custom message, the error should probably be checked manually and DEBUG_PRINT() called directly.
+ *       require a custom message, the error should probably be checked manually and DEBUG_PRINTLN() called directly.
  */
 #define CATCH_ERROR(function_call, success) do { \
     int _function_status = (function_call); \
     if (_function_status != success) { \
-        DEBUG_PRINT("CATCH_ERROR(): Function failed: %s (Status: %d)", #function_call, _function_status); \
+        DEBUG_PRINTLN("CATCH_ERROR(): Function failed: %s (Status: %d)", #function_call, _function_status); \
         return _function_status; \
     } \
 } while(0)

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -13,7 +13,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     /* Init CAN interface */
     HAL_StatusTypeDef status = can_init(&can1, hcan);
     if(status != HAL_OK) {
-        DEBUG_PRINT("Failed to execute can_init() when initializing can1 (Status: %d).", status);
+        DEBUG_PRINTLN("Failed to execute can_init() when initializing can1 (Status: %d).", status);
         return U_ERROR;
     }
 
@@ -21,7 +21,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     uint16_t standard[] = {0x00, 0x00};
     status = can_add_filter_standard(&can1, standard);
     if(status != HAL_OK) {
-        DEBUG_PRINT("Failed to add standard filter to can1 (Status: %d, ID1: %d, ID2: %d).", status, standard[0], standard[1]);
+        DEBUG_PRINTLN("Failed to add standard filter to can1 (Status: %d, ID1: %d, ID2: %d).", status, standard[0], standard[1]);
         return U_ERROR;
     }
 
@@ -29,7 +29,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     uint32_t extended[] = {0x00, 0x00};
     status = can_add_filter_extended(&can1, extended);
     if (status != HAL_OK) {
-        DEBUG_PRINT("Failed to add extended filter to can1 (Status: %d, ID1: %ld, ID2: %ld).", status, extended[0], extended[1]);
+        DEBUG_PRINTLN("Failed to add extended filter to can1 (Status: %d, ID1: %ld, ID2: %ld).", status, extended[0], extended[1]);
         return U_ERROR;
     }
 

--- a/Core/Src/u_ethernet.c
+++ b/Core/Src/u_ethernet.c
@@ -51,12 +51,12 @@ static void _receive_message(NX_UDP_SOCKET *socket) {
             &bytes_copied                   // Stores how many bytes were actually copied to &message
         );
         if(bytes_copied < sizeof(ethernet_message_t)) {
-            DEBUG_PRINT("WARNING: Received ethernet message was smaller than expected (only received %lu of %u expected bytes).", bytes_copied, sizeof(ethernet_message_t));
+            DEBUG_PRINTLN("WARNING: Received ethernet message was smaller than expected (only received %lu of %u expected bytes).", bytes_copied, sizeof(ethernet_message_t));
         }
 
         /* Process received message */
         if(status == NX_SUCCESS) {
-            DEBUG_PRINT("Received ethernet message! (Sender ID: %d, Message ID: %d).", message.sender_id, message.message_id);
+            DEBUG_PRINTLN("Received ethernet message! (Sender ID: %d, Message ID: %d).", message.sender_id, message.message_id);
             queue_send(&eth_incoming, &message);
         }
     }
@@ -73,7 +73,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
 
     /* Make sure device isn't already initialized */
     if(device.is_initialized) {
-        DEBUG_PRINT("ERROR: Ethernet is already initialized.");
+        DEBUG_PRINTLN("ERROR: Ethernet is already initialized.");
         return U_ERROR;
     }
 
@@ -89,7 +89,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _PACKET_POOL_SIZE           // Size of the pool's memory area
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to create packet pool (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to create packet pool (Status: %d).", status);
         return status;
     }
 
@@ -106,7 +106,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _IP_THREAD_PRIORITY                  // Priority of the IP thread
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to create IP instance (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to create IP instance (Status: %d).", status);
         return status;
     }
 
@@ -117,7 +117,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _ARP_CACHE_SIZE            // Size of ARP cache
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to enable ARP (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to enable ARP (Status: %d).", status);
         return status;
     }
 
@@ -125,14 +125,14 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
     /* Enable UDP */
     status = nx_udp_enable(&device.ip);
     if (status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to enable UDP (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to enable UDP (Status: %d).", status);
         return status;
     }
 
     /* Enable igmp */
     status = nx_igmp_enable(&device.ip);
     if (status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to enable igmp (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to enable igmp (Status: %d).", status);
         return status;
     }
 
@@ -150,7 +150,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
             ULONG address = ETH_IP(i);
             status = nx_igmp_multicast_join(&device.ip, address);
             if(status != NX_SUCCESS) {
-                DEBUG_PRINT("ERROR: Failed to join multicast group (Status: %d, Address: %lu).", status, address);
+                DEBUG_PRINTLN("ERROR: Failed to join multicast group (Status: %d, Address: %lu).", status, address);
             }
         }
     }
@@ -166,7 +166,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _UDP_QUEUE_MAXIMUM          // UDP queue maximum
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to create UDP socket (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to create UDP socket (Status: %d).", status);
         return status;
     }
 
@@ -177,7 +177,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         TX_WAIT_FOREVER              // Wait forever
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to bind UDP socket (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to bind UDP socket (Status: %d).", status);
         nx_udp_socket_delete(&device.socket);
         return status;
     }
@@ -188,7 +188,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         &_receive_message             // Callback function
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to set recieve callback (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to set recieve callback (Status: %d).", status);
         nx_udp_socket_unbind(&device.socket);
         nx_udp_socket_delete(&device.socket);
         return status;
@@ -197,7 +197,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
     /* Mark device as initialized. */
     device.is_initialized = true;
 
-    DEBUG_PRINT("Ethernet initialized successfully!");
+    DEBUG_PRINTLN("Ethernet initialized successfully!");
     return NX_SUCCESS;
 }
 
@@ -207,7 +207,7 @@ ethernet_message_t ethernet_create_message(uint8_t message_id, ethernet_node_t r
 
     /* Check data length */
     if (data_length > ETH_MESSAGE_SIZE) {
-        DEBUG_PRINT("ERROR: Data length exceeds maximum (message_id: %d).", message_id);
+        DEBUG_PRINTLN("ERROR: Data length exceeds maximum (message_id: %d).", message_id);
         return message; // Return empty message.
     }
 
@@ -228,13 +228,13 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
 
     /* Check if ethernet is initialized */
     if(!device.is_initialized) {
-        DEBUG_PRINT("ERROR: Ethernet device is not initialized, so ethernet_send_message() will not work.");
+        DEBUG_PRINTLN("ERROR: Ethernet device is not initialized, so ethernet_send_message() will not work.");
         return U_ERROR;
     }
 
     /* Check data length */
     if (message->data_length > ETH_MESSAGE_SIZE) {
-        DEBUG_PRINT("ERROR: Data length exceeds maximum (Message ID: %d).", message->message_id);
+        DEBUG_PRINTLN("ERROR: Data length exceeds maximum (Message ID: %d).", message->message_id);
         return U_ERROR;
     }
 
@@ -246,7 +246,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         TX_WAIT_FOREVER             // Wait indefinitely until a packet is available
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to allocate packet (Status: %d, Message ID: %d).", status, message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to allocate packet (Status: %d, Message ID: %d).", status, message->message_id);
         return U_ERROR;
     }
 
@@ -259,7 +259,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         TX_WAIT_FOREVER             // Wait indefinitely
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to append data to packet (Status: %d, Message ID: %d).", status, message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to append data to packet (Status: %d, Message ID: %d).", status, message->message_id);
         nx_packet_release(packet);
         return U_ERROR;
     }
@@ -272,11 +272,11 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         ETH_UDP_PORT
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to send packet (Status: %d, Message ID: %d).", status, message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to send packet (Status: %d, Message ID: %d).", status, message->message_id);
         nx_packet_release(packet);
         return U_ERROR;
     }
 
-    DEBUG_PRINT("Sent ethernet message (Recipient ID: %d, Message ID: %d).", message->recipient_id, message->message_id);
+    DEBUG_PRINTLN("Sent ethernet message (Recipient ID: %d, Message ID: %d).", message->recipient_id, message->message_id);
     return U_SUCCESS;
 }

--- a/Core/Src/u_queues.c
+++ b/Core/Src/u_queues.c
@@ -61,7 +61,7 @@ static uint8_t _create_queue(TX_BYTE_POOL *byte_pool, const QUEUE_CONFIG *config
     /* Basically, queue messages have to be a multiple of 4 bytes? Kinda weird but this should handle it. */
     UINT message_size_words = (config->message_size + 3) / 4;
     if (message_size_words < 1 || message_size_words > 16) {
-        DEBUG_PRINT("ERROR: Invalid message size %d bytes (must be 1-64 bytes). Queue: %s", 
+        DEBUG_PRINTLN("ERROR: Invalid message size %d bytes (must be 1-64 bytes). Queue: %s", 
                     config->message_size, config->name);
         return U_ERROR;
     }
@@ -76,14 +76,14 @@ static uint8_t _create_queue(TX_BYTE_POOL *byte_pool, const QUEUE_CONFIG *config
     /* Allocate the stack for the queue. */
     status = tx_byte_allocate(byte_pool, (VOID**) &pointer, queue_size_bytes, TX_NO_WAIT);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to allocate memory before creating queue (Status: %d, Queue: %s).", status, config->name);
+        DEBUG_PRINTLN("ERROR: Failed to allocate memory before creating queue (Status: %d, Queue: %s).", status, config->name);
         return U_ERROR;
     }
 
     /* Create the queue */
     status = tx_queue_create(&config->queue->_TX_QUEUE, config->name, message_size_words, pointer, queue_size_bytes);
     if (status != TX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to create queue (Status: %d, Queue: %s).", status, config->name);
+        DEBUG_PRINTLN("ERROR: Failed to create queue (Status: %d, Queue: %s).", status, config->name);
         tx_byte_release(pointer); // Free allocated memory if queue creation fails
         return U_ERROR;
     }
@@ -103,7 +103,7 @@ uint8_t queues_init(TX_BYTE_POOL *byte_pool) {
     CATCH_ERROR(_create_queue(byte_pool, &_can_incoming_config), U_SUCCESS); // Create Incoming CAN Queue
     CATCH_ERROR(_create_queue(byte_pool, &_can_outgoing_config), U_SUCCESS); // Create Outgoing CAN Queue
 
-    DEBUG_PRINT("Ran queues_init().");
+    DEBUG_PRINTLN("Ran queues_init().");
     return U_SUCCESS;
 }
 
@@ -120,7 +120,7 @@ uint8_t queue_send(queue_t *queue, void *message) {
     /* Send message (buffer) to the queue. */
     status = tx_queue_send(&queue->_TX_QUEUE, buffer, QUEUE_WAIT_TIME);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to send message to queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
+        DEBUG_PRINTLN("ERROR: Failed to send message to queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }
 
@@ -141,7 +141,7 @@ uint8_t  queue_receive(queue_t *queue, void *message) {
     }
 
     if((status != TX_SUCCESS)) {
-        DEBUG_PRINT("ERROR: Failed to receive message from queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
+        DEBUG_PRINTLN("ERROR: Failed to receive message from queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }
 

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -20,7 +20,7 @@ static uint8_t _button(uint8_t *data) {
 
         /* Do nothing by default. */
         default:
-            DEBUG_PRINT("NOTE: EVENT_BUTTON was triggered, but no action was taken based on the car's state (current_state=%d).", current_state);
+            DEBUG_PRINTLN("NOTE: EVENT_BUTTON was triggered, but no action was taken based on the car's state (current_state=%d).", current_state);
             return U_SUCCESS;
     }
 }
@@ -38,7 +38,7 @@ static uint8_t _dial(uint8_t *data) {
 
         /* Do nothing by default. */
         default:
-            DEBUG_PRINT("NOTE: EVENT_DIAL was triggered, but no action was taken based on the car's state (current_state=%d).", current_state);
+            DEBUG_PRINTLN("NOTE: EVENT_DIAL was triggered, but no action was taken based on the car's state (current_state=%d).", current_state);
             return U_SUCCESS;
     }
 }
@@ -52,7 +52,7 @@ uint8_t statemachine_process_event(event_t event, uint8_t *data) {
         
         /* If an invalid event is passed in, return an error. */
         default: 
-            DEBUG_PRINT("Invalid event passed into function. (Event: %d)", event);
+            DEBUG_PRINTLN("Invalid event passed into function. (Event: %d)", event);
             return U_ERROR;
     }
 }

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -55,7 +55,7 @@ void ethernet_thread(ULONG thread_input) {
         while(queue_receive(&eth_outgoing, &message) == U_SUCCESS) {
             status = ethernet_send_message(&message);
             if(status != U_SUCCESS) {
-                DEBUG_PRINT("WARNING: Failed to send Ethernet message after removing from outgoing queue (Message ID: %d).", message.message_id);
+                DEBUG_PRINTLN("WARNING: Failed to send Ethernet message after removing from outgoing queue (Message ID: %d).", message.message_id);
                 // u_TODO - maybe add the message back into the queue if it fails to send? not sure if this is a good idea tho
                 }
         }
@@ -94,7 +94,7 @@ void can_thread(ULONG thread_input) {
         while(queue_receive(&can_outgoing, &message) == U_SUCCESS) {
             status = can_send_msg(&can1, &message);
             if(status != U_SUCCESS) {
-                DEBUG_PRINT("WARNING: Failed to send message (on can1) after removing from outgoing queue (Message ID: %ld).", message.id);
+                DEBUG_PRINTLN("WARNING: Failed to send message (on can1) after removing from outgoing queue (Message ID: %ld).", message.id);
                 // u_TODO - maybe add the message back into the queue if it fails to send? not sure if this is a good idea tho
                 }
         }
@@ -117,14 +117,14 @@ static uint8_t _create_thread(TX_BYTE_POOL *byte_pool, const thread_t *thread) {
     /* Allocate the stack for the thread. */
     status = tx_byte_allocate(byte_pool, (VOID**) &pointer, thread->size, TX_NO_WAIT);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to allocate stack before creating thread (Status: %d, Thread: %s).", status, thread->name);
+        DEBUG_PRINTLN("ERROR: Failed to allocate stack before creating thread (Status: %d, Thread: %s).", status, thread->name);
         return U_ERROR;
     }
 
     /* Create the thread. */
     status = tx_thread_create(thread->thread, thread->name, thread->function, thread->thread_input, pointer, thread->size, thread->priority, thread->threshold, thread->time_slice, thread->auto_start);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINT("ERROR: Failed to create thread (Status: %d, Thread: %s).", status, thread->name);
+        DEBUG_PRINTLN("ERROR: Failed to create thread (Status: %d, Thread: %s).", status, thread->name);
         tx_byte_release(pointer); // Free allocated memory if thread creation fails
         return U_ERROR;
     }
@@ -143,6 +143,6 @@ uint8_t threads_init(TX_BYTE_POOL *byte_pool) {
     CATCH_ERROR(_create_thread(byte_pool, &_can_thread_config), U_SUCCESS);      // Create CAN thread.
     // add more threads here if need eventually
 
-    DEBUG_PRINT("Ran threads_init().");
+    DEBUG_PRINTLN("Ran threads_init().");
     return U_SUCCESS;
 }


### PR DESCRIPTION
Changed `DEBUG_PRINT()` macro to `DEBUG_PRINTLN()`. Thought this was a clearer name since the macro automatically prints `\n` at the end of each message.