### PR TITLE
Made it so queues and threads only have one struct.

### DIFF
--- a/Core/Inc/u_queues.h
+++ b/Core/Inc/u_queues.h
@@ -18,11 +18,12 @@
 typedef struct {
 
     /* Queue configuration settings. Set when defining an instance of this struct. */
-    CHAR     *name;          /* Name of the queue */
-    UINT      message_size;  /* Size of each message in the queue, in bytes. */
-    UINT      capacity;      /* Maximum number of messages in the queue */
+    CHAR            *name;         /* Name of the queue */
+    const UINT      message_size;  /* Size of each message in the queue, in bytes. */
+    const UINT      capacity;      /* Maximum number of messages in the queue */
 
-    /* Internal information (managed by u_queues.c). Shouldn't need to be messed with directly outside of that file. */
+    /* Internal information */
+    /* (Should only be accessed/modified through the u_queues.c API functions.) */
     TX_QUEUE _TX_QUEUE;      /* Queue instance. */
     size_t   _bytes;         /* Size of each queue message, in bytes. */
     size_t   _words;         /* Size of each queue message, in 32-bit words. */

--- a/Core/Inc/u_queues.h
+++ b/Core/Inc/u_queues.h
@@ -16,9 +16,16 @@
 #define QUEUE_WAIT_TIME     MS_TO_TICKS(100) // Wait 100ms for queue stuff before timing out
 
 typedef struct {
+
+    /* Queue configuration settings. Set when defining an instance of this struct. */
+    CHAR     *name;          /* Name of the queue */
+    UINT      message_size;  /* Size of each message in the queue, in bytes. */
+    UINT      capacity;      /* Maximum number of messages in the queue */
+
+    /* Internal information (managed by u_queues.c). Shouldn't need to be messed with directly outside of that file. */
     TX_QUEUE _TX_QUEUE;      /* Queue instance. */
-    size_t   bytes;           /* Size of each queue message, in bytes. */
-    size_t   words;           /* Size of each queue message, in 32-bit words. */
+    size_t   _bytes;         /* Size of each queue message, in bytes. */
+    size_t   _words;         /* Size of each queue message, in 32-bit words. */
 } queue_t;
 
 /* Queue List */
@@ -33,13 +40,5 @@ extern queue_t faults;       // Faults Queue
 uint8_t queues_init(TX_BYTE_POOL *byte_pool); // Initializes all queues. Called from app_threadx.c
 uint8_t queue_send(queue_t *queue, void *message); // Sends a message to the specified queue.
 uint8_t queue_receive(queue_t *queue, void *message); // Receives a message from the specified queue.
-
-/* Struct for configuring queues. */
-typedef struct {
-    queue_t  *queue;         /* Pointer to the queue instance */
-    CHAR     *name;          /* Name of the queue */
-    UINT      message_size;  /* Size of each message in the queue, in bytes. */
-    UINT      capacity;      /* Maximum number of messages in the queue */
-} QUEUE_CONFIG;
 
 #endif /* u_queues.h */

--- a/Core/Inc/u_threads.h
+++ b/Core/Inc/u_threads.h
@@ -16,16 +16,20 @@
 uint8_t threads_init(TX_BYTE_POOL *byte_pool);
 
 typedef struct {
-    TX_THREAD *thread;                    /* Thread */
-    CHAR      *name;                      /* Name of Thread */
-    VOID      (*function)(ULONG);         /* Thread Function */
-    ULONG     thread_input;               /* Thread Input. You can put whatever you want in here. Defaults to zero. */
-    ULONG     size;                       /* Stack Size (in bytes) */
-    UINT      priority;                   /* Priority */
-    UINT      threshold;                  /* Preemption Threshold */
-    ULONG     time_slice;                 /* Time Slice */
-    UINT      auto_start;                 /* Auto Start */
-    UINT      sleep;                      /* Sleep (in ticks) */
+    /* Thread configuration settings. Set when defining an instance of this struct. */
+    CHAR            *name;                /* Name of Thread */
+    VOID            (*function)(ULONG);   /* Thread Function */
+    const ULONG     thread_input;         /* Thread Input. You can put whatever you want in here. Defaults to zero. */
+    const ULONG     size;                 /* Stack Size (in bytes) */
+    const UINT      priority;             /* Priority */
+    const UINT      threshold;            /* Preemption Threshold */
+    const ULONG     time_slice;           /* Time Slice */
+    const UINT      auto_start;           /* Auto Start */
+    const UINT      sleep;                /* Sleep (in ticks) */
+
+    /* The actual thread instance. */
+    /* Since this is an internal ThreadX thing, it should only be modified using the ThreadX API functions. */
+    TX_THREAD _TX_THREAD;
 } thread_t;
 
 /* Thread Functions */


### PR DESCRIPTION
Used to have one `const` struct for queue/thread configuration, and another struct that actually held the internal information used/modified by ThreadX. I figured this was over-complicating things, so there's now just one `queue_t` and `thread_t`.