### PR TITLE
Debug Macros -> Printable Strings

### DIFF
--- a/AZURE_RTOS/App/app_azure_rtos.c
+++ b/AZURE_RTOS/App/app_azure_rtos.c
@@ -22,7 +22,7 @@
 #include "app_azure_rtos.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-#include "u_config.h"
+#include "u_general.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
     "./Core/Src/u_can.c"
     "./Core/Src/u_faults.c"
     "./Core/Src/u_mutexes.c"
+    "./Core/Src/u_general.c"
     "./Drivers/Embedded-Base/middleware/src/bitstream.c"
 )
 

--- a/Core/Inc/u_ethernet.h
+++ b/Core/Inc/u_ethernet.h
@@ -1,7 +1,7 @@
 #ifndef __U_ETHERNET_H
 #define __U_ETHERNET_H
 
-#include "u_config.h"
+#include "u_general.h"
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/Core/Inc/u_general.h
+++ b/Core/Inc/u_general.h
@@ -1,10 +1,14 @@
-#ifndef __U_CONFIG_H
-#define __U_CONFIG_H
+#ifndef __U_GENERAL_H
+#define __U_GENERAL_H
 
 #include <string.h>
 #include <stdio.h>
+#include "tx_port.h"
+#include "stm32h5xx_hal.h"
 
-/* General-purpose macros that can be used throughout the project. */
+/* This file (and u_general.c) contain miscellaneous macros, functions, and configuration settings that can be used throughout the project. */
+
+/* General-purpose status macros. */
 #define U_SUCCESS     0
 #define U_ERROR       1
 #define U_QUEUE_EMPTY 2
@@ -35,8 +39,13 @@
 } while(0)
 
 /* Time and tick conversions */
-#define MS_TO_TICKS(ms) (((ms) * TX_TIMER_TICKS_PER_SECOND + 999) / 1000) // 
+#define MS_TO_TICKS(ms) (((ms) * TX_TIMER_TICKS_PER_SECOND + 999) / 1000)
 #define TICKS_TO_MS(ticks)  ((ticks) * 1000 / TX_TIMER_TICKS_PER_SECOND)
 
+/* These functions convert status macros to a printable string. */
+/* They are intended to be used with DEBUG_PRINTLN(), and shouldn't really be used outside of debugging purposes. */
+const char* tx_status_toString(UINT status); // Converts a ThreadX status macro to a printable string.
+const char* nx_status_toString(UINT status); // Converts a NetX status macro to a printable string.
+const char* hal_status_toString(HAL_StatusTypeDef status); // Converts a HAL status macro to a printable string.
 
-#endif /* u_config.h */
+#endif /* u_general.h */

--- a/Core/Inc/u_queues.h
+++ b/Core/Inc/u_queues.h
@@ -2,7 +2,7 @@
 #define __U_QUEUES_H
 
 #include "tx_api.h"
-#include "u_config.h"
+#include "u_general.h"
 #include "u_ethernet.h"
 #include <stdint.h>
 

--- a/Core/Inc/u_statemachine.h
+++ b/Core/Inc/u_statemachine.h
@@ -1,7 +1,7 @@
 #ifndef __STATEMACHINE_H
 #define __STATEMACHINE_H
 
-#include "u_config.h"
+#include "u_general.h"
 #include <stdint.h>
 #include <stdio.h>
 

--- a/Core/Inc/u_threads.h
+++ b/Core/Inc/u_threads.h
@@ -2,7 +2,7 @@
 #define __U_THREADS_H
 
 #include "tx_api.h"
-#include "u_config.h"
+#include "u_general.h"
 #include <stdint.h>
 #include <stdio.h>
 

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -13,7 +13,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     /* Init CAN interface */
     HAL_StatusTypeDef status = can_init(&can1, hcan);
     if(status != HAL_OK) {
-        DEBUG_PRINTLN("Failed to execute can_init() when initializing can1 (Status: %s).", hal_status_toString(status));
+        DEBUG_PRINTLN("Failed to execute can_init() when initializing can1 (Status: %d/%s).", status, hal_status_toString(status));
         return U_ERROR;
     }
 
@@ -21,7 +21,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     uint16_t standard[] = {0x00, 0x00};
     status = can_add_filter_standard(&can1, standard);
     if(status != HAL_OK) {
-        DEBUG_PRINTLN("Failed to add standard filter to can1 (Status: %s, ID1: %d, ID2: %d).", hal_status_toString(status), standard[0], standard[1]);
+        DEBUG_PRINTLN("Failed to add standard filter to can1 (Status: %d/%s, ID1: %d, ID2: %d).", status, hal_status_toString(status), standard[0], standard[1]);
         return U_ERROR;
     }
 
@@ -29,7 +29,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     uint32_t extended[] = {0x00, 0x00};
     status = can_add_filter_extended(&can1, extended);
     if (status != HAL_OK) {
-        DEBUG_PRINTLN("Failed to add extended filter to can1 (Status: %s, ID1: %ld, ID2: %ld).", hal_status_toString(status), extended[0], extended[1]);
+        DEBUG_PRINTLN("Failed to add extended filter to can1 (Status: %d/%s, ID1: %ld, ID2: %ld).", status, hal_status_toString(status), extended[0], extended[1]);
         return U_ERROR;
     }
 

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include "u_can.h"
-#include "u_config.h"
+#include "u_general.h"
 #include "stm32h5xx_hal.h"
 
 
@@ -13,7 +13,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     /* Init CAN interface */
     HAL_StatusTypeDef status = can_init(&can1, hcan);
     if(status != HAL_OK) {
-        DEBUG_PRINTLN("Failed to execute can_init() when initializing can1 (Status: %d).", status);
+        DEBUG_PRINTLN("Failed to execute can_init() when initializing can1 (Status: %s).", hal_status_toString(status));
         return U_ERROR;
     }
 
@@ -21,7 +21,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     uint16_t standard[] = {0x00, 0x00};
     status = can_add_filter_standard(&can1, standard);
     if(status != HAL_OK) {
-        DEBUG_PRINTLN("Failed to add standard filter to can1 (Status: %d, ID1: %d, ID2: %d).", status, standard[0], standard[1]);
+        DEBUG_PRINTLN("Failed to add standard filter to can1 (Status: %s, ID1: %d, ID2: %d).", hal_status_toString(status), standard[0], standard[1]);
         return U_ERROR;
     }
 
@@ -29,7 +29,7 @@ uint8_t can1_init(FDCAN_HandleTypeDef *hcan) {
     uint32_t extended[] = {0x00, 0x00};
     status = can_add_filter_extended(&can1, extended);
     if (status != HAL_OK) {
-        DEBUG_PRINTLN("Failed to add extended filter to can1 (Status: %d, ID1: %ld, ID2: %ld).", status, extended[0], extended[1]);
+        DEBUG_PRINTLN("Failed to add extended filter to can1 (Status: %s, ID1: %ld, ID2: %ld).", hal_status_toString(status), extended[0], extended[1]);
         return U_ERROR;
     }
 

--- a/Core/Src/u_ethernet.c
+++ b/Core/Src/u_ethernet.c
@@ -3,7 +3,6 @@
 #include "u_general.h"
 #include "nx_api.h"
 #include "nx_stm32_eth_driver.h"
-#include "u_general.h"
 #include <string.h>
 #include <stdio.h>
 

--- a/Core/Src/u_ethernet.c
+++ b/Core/Src/u_ethernet.c
@@ -89,7 +89,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _PACKET_POOL_SIZE           // Size of the pool's memory area
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create packet pool (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to create packet pool (Status: %d/%s).", status, nx_status_toString(status));
         return status;
     }
 
@@ -106,7 +106,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _IP_THREAD_PRIORITY                  // Priority of the IP thread
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create IP instance (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to create IP instance (Status: %d/%s).", status, nx_status_toString(status));
         return status;
     }
 
@@ -117,7 +117,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _ARP_CACHE_SIZE            // Size of ARP cache
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to enable ARP (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to enable ARP (Status: %d/%s).", status, nx_status_toString(status));
         return status;
     }
 
@@ -125,14 +125,14 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
     /* Enable UDP */
     status = nx_udp_enable(&device.ip);
     if (status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to enable UDP (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to enable UDP (Status: %d/%s).", status, nx_status_toString(status));
         return status;
     }
 
     /* Enable igmp */
     status = nx_igmp_enable(&device.ip);
     if (status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to enable igmp (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to enable igmp (Status: %d/%s).", status, nx_status_toString(status));
         return status;
     }
 
@@ -150,7 +150,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
             ULONG address = ETH_IP(i);
             status = nx_igmp_multicast_join(&device.ip, address);
             if(status != NX_SUCCESS) {
-                DEBUG_PRINTLN("ERROR: Failed to join multicast group (Status: %s, Address: %lu).", nx_status_toString(status), address);
+                DEBUG_PRINTLN("ERROR: Failed to join multicast group (Status: %d/%s, Address: %lu).", status, nx_status_toString(status), address);
             }
         }
     }
@@ -166,7 +166,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _UDP_QUEUE_MAXIMUM          // UDP queue maximum
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create UDP socket (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to create UDP socket (Status: %d/%s).", status, nx_status_toString(status));
         return status;
     }
 
@@ -177,7 +177,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         TX_WAIT_FOREVER              // Wait forever
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to bind UDP socket (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to bind UDP socket (Status: %d/%s).", status, nx_status_toString(status));
         nx_udp_socket_delete(&device.socket);
         return status;
     }
@@ -188,7 +188,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         &_receive_message             // Callback function
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to set recieve callback (Status: %s).", nx_status_toString(status));
+        DEBUG_PRINTLN("ERROR: Failed to set recieve callback (Status: %d/%s).", status, nx_status_toString(status));
         nx_udp_socket_unbind(&device.socket);
         nx_udp_socket_delete(&device.socket);
         return status;
@@ -246,7 +246,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         TX_WAIT_FOREVER             // Wait indefinitely until a packet is available
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate packet (Status: %s, Message ID: %d).", nx_status_toString(status), message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to allocate packet (Status: %d/%s, Message ID: %d).", status, nx_status_toString(status), message->message_id);
         return U_ERROR;
     }
 
@@ -259,7 +259,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         TX_WAIT_FOREVER             // Wait indefinitely
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to append data to packet (Status: %s, Message ID: %d).", nx_status_toString(status), message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to append data to packet (Status: %d/%s, Message ID: %d).", status, nx_status_toString(status), message->message_id);
         nx_packet_release(packet);
         return U_ERROR;
     }
@@ -272,7 +272,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         ETH_UDP_PORT
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to send packet (Status: %s, Message ID: %d).", nx_status_toString(status), message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to send packet (Status: %d/%s, Message ID: %d).", status, nx_status_toString(status), message->message_id);
         nx_packet_release(packet);
         return U_ERROR;
     }

--- a/Core/Src/u_ethernet.c
+++ b/Core/Src/u_ethernet.c
@@ -1,8 +1,9 @@
 #include "u_ethernet.h"
 #include "u_queues.h"
-#include "u_config.h"
+#include "u_general.h"
 #include "nx_api.h"
 #include "nx_stm32_eth_driver.h"
+#include "u_general.h"
 #include <string.h>
 #include <stdio.h>
 
@@ -89,7 +90,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _PACKET_POOL_SIZE           // Size of the pool's memory area
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create packet pool (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to create packet pool (Status: %s).", nx_status_toString(status));
         return status;
     }
 
@@ -106,7 +107,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _IP_THREAD_PRIORITY                  // Priority of the IP thread
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create IP instance (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to create IP instance (Status: %s).", nx_status_toString(status));
         return status;
     }
 
@@ -117,7 +118,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _ARP_CACHE_SIZE            // Size of ARP cache
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to enable ARP (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to enable ARP (Status: %s).", nx_status_toString(status));
         return status;
     }
 
@@ -125,14 +126,14 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
     /* Enable UDP */
     status = nx_udp_enable(&device.ip);
     if (status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to enable UDP (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to enable UDP (Status: %s).", nx_status_toString(status));
         return status;
     }
 
     /* Enable igmp */
     status = nx_igmp_enable(&device.ip);
     if (status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to enable igmp (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to enable igmp (Status: %s).", nx_status_toString(status));
         return status;
     }
 
@@ -150,7 +151,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
             ULONG address = ETH_IP(i);
             status = nx_igmp_multicast_join(&device.ip, address);
             if(status != NX_SUCCESS) {
-                DEBUG_PRINTLN("ERROR: Failed to join multicast group (Status: %d, Address: %lu).", status, address);
+                DEBUG_PRINTLN("ERROR: Failed to join multicast group (Status: %s, Address: %lu).", nx_status_toString(status), address);
             }
         }
     }
@@ -166,7 +167,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         _UDP_QUEUE_MAXIMUM          // UDP queue maximum
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create UDP socket (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to create UDP socket (Status: %s).", nx_status_toString(status));
         return status;
     }
 
@@ -177,7 +178,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         TX_WAIT_FOREVER              // Wait forever
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to bind UDP socket (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to bind UDP socket (Status: %s).", nx_status_toString(status));
         nx_udp_socket_delete(&device.socket);
         return status;
     }
@@ -188,7 +189,7 @@ uint8_t ethernet_init(ethernet_node_t node_id) {
         &_receive_message             // Callback function
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to set recieve callback (Status: %d).", status);
+        DEBUG_PRINTLN("ERROR: Failed to set recieve callback (Status: %s).", nx_status_toString(status));
         nx_udp_socket_unbind(&device.socket);
         nx_udp_socket_delete(&device.socket);
         return status;
@@ -246,7 +247,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         TX_WAIT_FOREVER             // Wait indefinitely until a packet is available
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate packet (Status: %d, Message ID: %d).", status, message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to allocate packet (Status: %s, Message ID: %d).", nx_status_toString(status), message->message_id);
         return U_ERROR;
     }
 
@@ -259,7 +260,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         TX_WAIT_FOREVER             // Wait indefinitely
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to append data to packet (Status: %d, Message ID: %d).", status, message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to append data to packet (Status: %s, Message ID: %d).", nx_status_toString(status), message->message_id);
         nx_packet_release(packet);
         return U_ERROR;
     }
@@ -272,7 +273,7 @@ uint8_t ethernet_send_message(ethernet_message_t *message) {
         ETH_UDP_PORT
     );
     if(status != NX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to send packet (Status: %d, Message ID: %d).", status, message->message_id);
+        DEBUG_PRINTLN("ERROR: Failed to send packet (Status: %s, Message ID: %d).", nx_status_toString(status), message->message_id);
         nx_packet_release(packet);
         return U_ERROR;
     }

--- a/Core/Src/u_faults.c
+++ b/Core/Src/u_faults.c
@@ -84,7 +84,7 @@ int faults_init(void) {
             TX_NO_ACTIVATE            /* Make the timer dormant until it is activated. */
         );
         if(status != TX_SUCCESS) {
-            DEBUG_PRINTLN("ERROR: Failed to create fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
+            DEBUG_PRINTLN("ERROR: Failed to create fault timer (Status: %d/%s, Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
             return U_ERROR;
         }
     }
@@ -113,21 +113,21 @@ int trigger_fault(fault_t fault_id) {
     /* Deactivate the fault timer. */
     int status = tx_timer_deactivate(&timers[fault_id]);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to deactivate fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to deactivate fault timer (Status: %d/%s, Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 
     /* Change the fault timer. */
     status = tx_timer_change(&timers[fault_id], faults[fault_id].timeout, 0);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to change fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to change fault timer (Status: %d/%s, Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 
     /* Activate the fault timer. */
     status = tx_timer_activate(&timers[fault_id]);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to activate fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to activate fault timer (Status: %d/%s, Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 

--- a/Core/Src/u_faults.c
+++ b/Core/Src/u_faults.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include "tx_api.h"
 #include "u_faults.h"
-#include "u_config.h"
+#include "u_general.h"
 
 typedef enum {
     CRITICAL,
@@ -84,7 +84,7 @@ int faults_init(void) {
             TX_NO_ACTIVATE            /* Make the timer dormant until it is activated. */
         );
         if(status != TX_SUCCESS) {
-            DEBUG_PRINTLN("ERROR: Failed to create fault timer (Status: %d, Fault: %s).", status, faults[fault_id].name);
+            DEBUG_PRINTLN("ERROR: Failed to create fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
             return U_ERROR;
         }
     }
@@ -113,21 +113,21 @@ int trigger_fault(fault_t fault_id) {
     /* Deactivate the fault timer. */
     int status = tx_timer_deactivate(&timers[fault_id]);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to deactivate fault timer (Status: %d, Fault: %s).", status, faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to deactivate fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 
     /* Change the fault timer. */
     status = tx_timer_change(&timers[fault_id], faults[fault_id].timeout, 0);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to change fault timer (Status: %d, Fault: %s).", status, faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to change fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 
     /* Activate the fault timer. */
     status = tx_timer_activate(&timers[fault_id]);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to activate fault timer (Status: %d, Fault: %s).", status, faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to activate fault timer (Status: %s, Fault: %s).", tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 

--- a/Core/Src/u_general.c
+++ b/Core/Src/u_general.c
@@ -47,7 +47,7 @@ const char* tx_status_toString(UINT status) {
         case TX_FEATURE_NOT_ENABLED: return "TX_FEATURE_NOT_ENABLED";
         default:
             /* Default is reached if the status code doesn't match any of the macros. */
-            static char status_string[16]; // Buffer to hold the status UINT as a string.
+            char status_string[16]; // Buffer to hold the status UINT as a string.
             snprintf(status_string, sizeof(status_string), "0x%02X", status);
             return status_string;
     }
@@ -125,7 +125,7 @@ const char* nx_status_toString(UINT status) {
         case NX_TCPIP_OFFLOAD_ERROR: return "NX_TCPIP_OFFLOAD_ERROR";
         default:
             /* Default is reached if the status code doesn't match any of the macros. */
-            static char status_string[16]; // Buffer to hold the status UINT as a string.
+            char status_string[16]; // Buffer to hold the status UINT as a string.
             snprintf(status_string, sizeof(status_string), "0x%02X", status);
             return status_string;
     }
@@ -142,7 +142,7 @@ const char* hal_status_toString(HAL_StatusTypeDef status) {
         case HAL_TIMEOUT: return "HAL_TIMEOUT";
         default:
             /* Default is reached if the status code doesn't match any of the macros. */
-            static char status_string[16]; // Buffer to hold the status HAL_StatusTypeDef as a string.
+            char status_string[16]; // Buffer to hold the status HAL_StatusTypeDef as a string.
             snprintf(status_string, sizeof(status_string), "0x%02X", status);
             return status_string;
     }

--- a/Core/Src/u_general.c
+++ b/Core/Src/u_general.c
@@ -1,0 +1,149 @@
+#include "u_general.h"
+#include "tx_api.h"
+#include "nx_api.h"
+#include "stm32h5xx_hal.h"
+#include <stdio.h>
+
+/* Converts a ThreadX status macro to a printable string. */
+/* This function is intended to be used with DEBUG_PRINTLN(), and shouldn't really ever be used outside of debugging purposes. */
+/* (these macros are defined in tx_api.h) */
+const char* tx_status_toString(UINT status) {
+    switch(status) {
+        case TX_SUCCESS: return "TX_SUCCESS";
+        case TX_DELETED: return "TX_DELETED";
+        case TX_POOL_ERROR: return "TX_POOL_ERROR";
+        case TX_PTR_ERROR: return "TX_PTR_ERROR";
+        case TX_WAIT_ERROR: return "TX_WAIT_ERROR";
+        case TX_SIZE_ERROR: return "TX_SIZE_ERROR";
+        case TX_GROUP_ERROR: return "TX_GROUP_ERROR";
+        case TX_NO_EVENTS: return "TX_NO_EVENTS";
+        case TX_OPTION_ERROR: return "TX_OPTION_ERROR";
+        case TX_QUEUE_ERROR: return "TX_QUEUE_ERROR";
+        case TX_QUEUE_EMPTY: return "TX_QUEUE_EMPTY";
+        case TX_QUEUE_FULL: return "TX_QUEUE_FULL";
+        case TX_SEMAPHORE_ERROR: return "TX_SEMAPHORE_ERROR";
+        case TX_NO_INSTANCE: return "TX_NO_INSTANCE";
+        case TX_THREAD_ERROR: return "TX_THREAD_ERROR";
+        case TX_PRIORITY_ERROR: return "TX_PRIORITY_ERROR";
+        case TX_NO_MEMORY: return "TX_NO_MEMORY"; // Same as TX_START_ERROR
+        case TX_DELETE_ERROR: return "TX_DELETE_ERROR";
+        case TX_RESUME_ERROR: return "TX_RESUME_ERROR";
+        case TX_CALLER_ERROR: return "TX_CALLER_ERROR";
+        case TX_SUSPEND_ERROR: return "TX_SUSPEND_ERROR";
+        case TX_TIMER_ERROR: return "TX_TIMER_ERROR";
+        case TX_TICK_ERROR: return "TX_TICK_ERROR";
+        case TX_ACTIVATE_ERROR: return "TX_ACTIVATE_ERROR";
+        case TX_THRESH_ERROR: return "TX_THRESH_ERROR";
+        case TX_SUSPEND_LIFTED: return "TX_SUSPEND_LIFTED";
+        case TX_WAIT_ABORTED: return "TX_WAIT_ABORTED";
+        case TX_WAIT_ABORT_ERROR: return "TX_WAIT_ABORT_ERROR";
+        case TX_MUTEX_ERROR: return "TX_MUTEX_ERROR";
+        case TX_NOT_AVAILABLE: return "TX_NOT_AVAILABLE";
+        case TX_NOT_OWNED: return "TX_NOT_OWNED";
+        case TX_INHERIT_ERROR: return "TX_INHERIT_ERROR";
+        case TX_NOT_DONE: return "TX_NOT_DONE";
+        case TX_CEILING_EXCEEDED: return "TX_CEILING_EXCEEDED";
+        case TX_INVALID_CEILING: return "TX_INVALID_CEILING";
+        case TX_FEATURE_NOT_ENABLED: return "TX_FEATURE_NOT_ENABLED";
+        default:
+            /* Default is reached if the status code doesn't match any of the macros. */
+            static char status_string[16]; // Buffer to hold the status UINT as a string.
+            snprintf(status_string, sizeof(status_string), "0x%02X", status);
+            return status_string;
+    }
+}
+
+/* Converts a NetX status macro to a printable string. */
+/* This function is intended to be used with DEBUG_PRINTLN(), and shouldn't really ever be used outside of debugging purposes. */
+/* (these macros are defined in nx_api.h) */
+const char* nx_status_toString(UINT status) {
+    switch(status) {
+        case NX_SUCCESS: return "NX_SUCCESS";
+        case NX_NO_PACKET: return "NX_NO_PACKET";
+        case NX_UNDERFLOW: return "NX_UNDERFLOW";
+        case NX_OVERFLOW: return "NX_OVERFLOW";
+        case NX_NO_MAPPING: return "NX_NO_MAPPING";
+        case NX_DELETED: return "NX_DELETED";
+        case NX_POOL_ERROR: return "NX_POOL_ERROR";
+        case NX_PTR_ERROR: return "NX_PTR_ERROR";
+        case NX_WAIT_ERROR: return "NX_WAIT_ERROR";
+        case NX_SIZE_ERROR: return "NX_SIZE_ERROR";
+        case NX_OPTION_ERROR: return "NX_OPTION_ERROR";
+        case NX_DELETE_ERROR: return "NX_DELETE_ERROR";
+        case NX_CALLER_ERROR: return "NX_CALLER_ERROR";
+        case NX_INVALID_PACKET: return "NX_INVALID_PACKET";
+        case NX_INVALID_SOCKET: return "NX_INVALID_SOCKET";
+        case NX_NOT_ENABLED: return "NX_NOT_ENABLED";
+        case NX_ALREADY_ENABLED: return "NX_ALREADY_ENABLED";
+        case NX_ENTRY_NOT_FOUND: return "NX_ENTRY_NOT_FOUND";
+        case NX_NO_MORE_ENTRIES: return "NX_NO_MORE_ENTRIES";
+        case NX_ARP_TIMER_ERROR: return "NX_ARP_TIMER_ERROR";
+        case NX_RESERVED_CODE0: return "NX_RESERVED_CODE0";
+        case NX_WAIT_ABORTED: return "NX_WAIT_ABORTED";
+        case NX_IP_INTERNAL_ERROR: return "NX_IP_INTERNAL_ERROR";
+        case NX_IP_ADDRESS_ERROR: return "NX_IP_ADDRESS_ERROR";
+        case NX_ALREADY_BOUND: return "NX_ALREADY_BOUND";
+        case NX_PORT_UNAVAILABLE: return "NX_PORT_UNAVAILABLE";
+        case NX_NOT_BOUND: return "NX_NOT_BOUND";
+        case NX_RESERVED_CODE1: return "NX_RESERVED_CODE1";
+        case NX_SOCKET_UNBOUND: return "NX_SOCKET_UNBOUND";
+        case NX_NOT_CREATED: return "NX_NOT_CREATED";
+        case NX_SOCKETS_BOUND: return "NX_SOCKETS_BOUND";
+        case NX_NO_RESPONSE: return "NX_NO_RESPONSE";
+        case NX_POOL_DELETED: return "NX_POOL_DELETED";
+        case NX_ALREADY_RELEASED: return "NX_ALREADY_RELEASED";
+        case NX_RESERVED_CODE2: return "NX_RESERVED_CODE2";
+        case NX_MAX_LISTEN: return "NX_MAX_LISTEN";
+        case NX_DUPLICATE_LISTEN: return "NX_DUPLICATE_LISTEN";
+        case NX_NOT_CLOSED: return "NX_NOT_CLOSED";
+        case NX_NOT_LISTEN_STATE: return "NX_NOT_LISTEN_STATE";
+        case NX_IN_PROGRESS: return "NX_IN_PROGRESS";
+        case NX_NOT_CONNECTED: return "NX_NOT_CONNECTED";
+        case NX_WINDOW_OVERFLOW: return "NX_WINDOW_OVERFLOW";
+        case NX_ALREADY_SUSPENDED: return "NX_ALREADY_SUSPENDED";
+        case NX_DISCONNECT_FAILED: return "NX_DISCONNECT_FAILED";
+        case NX_STILL_BOUND: return "NX_STILL_BOUND";
+        case NX_NOT_SUCCESSFUL: return "NX_NOT_SUCCESSFUL";
+        case NX_UNHANDLED_COMMAND: return "NX_UNHANDLED_COMMAND";
+        case NX_NO_FREE_PORTS: return "NX_NO_FREE_PORTS";
+        case NX_INVALID_PORT: return "NX_INVALID_PORT";
+        case NX_INVALID_RELISTEN: return "NX_INVALID_RELISTEN";
+        case NX_CONNECTION_PENDING: return "NX_CONNECTION_PENDING";
+        case NX_TX_QUEUE_DEPTH: return "NX_TX_QUEUE_DEPTH";
+        case NX_NOT_IMPLEMENTED: return "NX_NOT_IMPLEMENTED";
+        case NX_NOT_SUPPORTED: return "NX_NOT_SUPPORTED";
+        case NX_INVALID_INTERFACE: return "NX_INVALID_INTERFACE";
+        case NX_INVALID_PARAMETERS: return "NX_INVALID_PARAMETERS";
+        case NX_NOT_FOUND: return "NX_NOT_FOUND";
+        case NX_CANNOT_START: return "NX_CANNOT_START";
+        case NX_NO_INTERFACE_ADDRESS: return "NX_NO_INTERFACE_ADDRESS";
+        case NX_INVALID_MTU_DATA: return "NX_INVALID_MTU_DATA";
+        case NX_DUPLICATED_ENTRY: return "NX_DUPLICATED_ENTRY";
+        case NX_PACKET_OFFSET_ERROR: return "NX_PACKET_OFFSET_ERROR";
+        case NX_OPTION_HEADER_ERROR: return "NX_OPTION_HEADER_ERROR";
+        case NX_CONTINUE: return "NX_CONTINUE";
+        case NX_TCPIP_OFFLOAD_ERROR: return "NX_TCPIP_OFFLOAD_ERROR";
+        default:
+            /* Default is reached if the status code doesn't match any of the macros. */
+            static char status_string[16]; // Buffer to hold the status UINT as a string.
+            snprintf(status_string, sizeof(status_string), "0x%02X", status);
+            return status_string;
+    }
+}
+
+/* Converts a STM32 HAL status macro to a printable string. */
+/* This function is intended to be used with DEBUG_PRINTLN(), and shouldn't really ever be used outside of debugging purposes. */
+/* (these macros are defined in stm32h5xx_hal_def.h) */
+const char* hal_status_toString(HAL_StatusTypeDef status) {
+    switch(status) {
+        case HAL_OK: return "HAL_OK";
+        case HAL_ERROR: return "HAL_ERROR";
+        case HAL_BUSY: return "HAL_BUSY";
+        case HAL_TIMEOUT: return "HAL_TIMEOUT";
+        default:
+            /* Default is reached if the status code doesn't match any of the macros. */
+            static char status_string[16]; // Buffer to hold the status HAL_StatusTypeDef as a string.
+            snprintf(status_string, sizeof(status_string), "0x%02X", status);
+            return status_string;
+    }
+}

--- a/Core/Src/u_general.c
+++ b/Core/Src/u_general.c
@@ -45,11 +45,7 @@ const char* tx_status_toString(UINT status) {
         case TX_CEILING_EXCEEDED: return "TX_CEILING_EXCEEDED";
         case TX_INVALID_CEILING: return "TX_INVALID_CEILING";
         case TX_FEATURE_NOT_ENABLED: return "TX_FEATURE_NOT_ENABLED";
-        default:
-            /* Default is reached if the status code doesn't match any of the macros. */
-            char status_string[16]; // Buffer to hold the status UINT as a string.
-            snprintf(status_string, sizeof(status_string), "0x%02X", status);
-            return status_string;
+        default: return "UNKNOWN_STATUS";
     }
 }
 
@@ -123,11 +119,7 @@ const char* nx_status_toString(UINT status) {
         case NX_OPTION_HEADER_ERROR: return "NX_OPTION_HEADER_ERROR";
         case NX_CONTINUE: return "NX_CONTINUE";
         case NX_TCPIP_OFFLOAD_ERROR: return "NX_TCPIP_OFFLOAD_ERROR";
-        default:
-            /* Default is reached if the status code doesn't match any of the macros. */
-            char status_string[16]; // Buffer to hold the status UINT as a string.
-            snprintf(status_string, sizeof(status_string), "0x%02X", status);
-            return status_string;
+        default: return "UNKNOWN_STATUS";
     }
 }
 
@@ -140,10 +132,6 @@ const char* hal_status_toString(HAL_StatusTypeDef status) {
         case HAL_ERROR: return "HAL_ERROR";
         case HAL_BUSY: return "HAL_BUSY";
         case HAL_TIMEOUT: return "HAL_TIMEOUT";
-        default:
-            /* Default is reached if the status code doesn't match any of the macros. */
-            char status_string[16]; // Buffer to hold the status HAL_StatusTypeDef as a string.
-            snprintf(status_string, sizeof(status_string), "0x%02X", status);
-            return status_string;
+        default: return "UNKNOWN_STATUS";
     }
 }

--- a/Core/Src/u_mutexes.c
+++ b/Core/Src/u_mutexes.c
@@ -13,7 +13,7 @@ mutex_t template_mutex = {
 static uint8_t _create_mutex(mutex_t *mutex) {
     uint8_t status = tx_mutex_create(&mutex->_TX_MUTEX, mutex->name, mutex->priority_inherit);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create mutex (Status: %s, Name: %s).", tx_status_toString(status), mutex->name);
+        DEBUG_PRINTLN("ERROR: Failed to create mutex (Status: %d/%s, Name: %s).", status, tx_status_toString(status), mutex->name);
         return status;
     }
 
@@ -36,7 +36,7 @@ uint8_t mutexes_init() {
 uint8_t mutex_get(mutex_t *mutex, ULONG wait_option) {
     uint8_t status = tx_mutex_get(&mutex->_TX_MUTEX, wait_option);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to get mutex (Status: %s, Mutex: %s).", tx_status_toString(status), mutex->name);
+        DEBUG_PRINTLN("ERROR: Failed to get mutex (Status: %d/%s, Mutex: %s).", status, tx_status_toString(status), mutex->name);
         return status;
     }
 
@@ -47,7 +47,7 @@ uint8_t mutex_get(mutex_t *mutex, ULONG wait_option) {
 uint8_t mutex_put(mutex_t *mutex) {
     uint8_t status = tx_mutex_put(&mutex->_TX_MUTEX);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to put mutex (Status: %s, Mutex: %s).", tx_status_toString(status), mutex->name);
+        DEBUG_PRINTLN("ERROR: Failed to put mutex (Status: %d/%s, Mutex: %s).", status, tx_status_toString(status), mutex->name);
         return status;
     }
 

--- a/Core/Src/u_mutexes.c
+++ b/Core/Src/u_mutexes.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "u_mutexes.h"
-#include "u_config.h"
+#include "u_general.h"
 
 /* Template Mutex */
 /* only exists to show how to create mutexes (since there aren't any as of writing this. can be removed once an actual real mutex is set up here. */
@@ -13,7 +13,7 @@ mutex_t template_mutex = {
 static uint8_t _create_mutex(mutex_t *mutex) {
     uint8_t status = tx_mutex_create(&mutex->_TX_MUTEX, mutex->name, mutex->priority_inherit);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create mutex (Status: %d, Name: %s).", status, mutex->name);
+        DEBUG_PRINTLN("ERROR: Failed to create mutex (Status: %s, Name: %s).", tx_status_toString(status), mutex->name);
         return status;
     }
 
@@ -36,7 +36,7 @@ uint8_t mutexes_init() {
 uint8_t mutex_get(mutex_t *mutex, ULONG wait_option) {
     uint8_t status = tx_mutex_get(&mutex->_TX_MUTEX, wait_option);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to get mutex (Status: %d, Mutex: %s).", status, mutex->name);
+        DEBUG_PRINTLN("ERROR: Failed to get mutex (Status: %s, Mutex: %s).", tx_status_toString(status), mutex->name);
         return status;
     }
 
@@ -47,7 +47,7 @@ uint8_t mutex_get(mutex_t *mutex, ULONG wait_option) {
 uint8_t mutex_put(mutex_t *mutex) {
     uint8_t status = tx_mutex_put(&mutex->_TX_MUTEX);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to put mutex (Status: %d, Mutex: %s).", status, mutex->name);
+        DEBUG_PRINTLN("ERROR: Failed to put mutex (Status: %s, Mutex: %s).", tx_status_toString(status), mutex->name);
         return status;
     }
 

--- a/Core/Src/u_queues.c
+++ b/Core/Src/u_queues.c
@@ -1,6 +1,6 @@
 #include "u_queues.h"
 #include "u_can.h"
-#include "u_config.h"
+#include "u_general.h"
 #include "u_faults.h"
 #include <stdio.h>
 
@@ -76,14 +76,14 @@ static uint8_t _create_queue(TX_BYTE_POOL *byte_pool, queue_t *queue) {
     /* Allocate the stack for the queue. */
     status = tx_byte_allocate(byte_pool, (VOID**) &pointer, queue_size_bytes, TX_NO_WAIT);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate memory before creating queue (Status: %d, Queue: %s).", status, queue->name);
+        DEBUG_PRINTLN("ERROR: Failed to allocate memory before creating queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->name);
         return U_ERROR;
     }
 
     /* Create the queue */
     status = tx_queue_create(&queue->_TX_QUEUE, queue->name, message_size_words, pointer, queue_size_bytes);
     if (status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create queue (Status: %d, Queue: %s).", status, queue->name);
+        DEBUG_PRINTLN("ERROR: Failed to create queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->name);
         tx_byte_release(pointer); // Free allocated memory if queue creation fails
         return U_ERROR;
     }
@@ -121,7 +121,7 @@ uint8_t queue_send(queue_t *queue, void *message) {
     /* Send message (buffer) to the queue. */
     status = tx_queue_send(&queue->_TX_QUEUE, buffer, QUEUE_WAIT_TIME);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to send message to queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
+        DEBUG_PRINTLN("ERROR: Failed to send message to queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }
 
@@ -142,7 +142,7 @@ uint8_t  queue_receive(queue_t *queue, void *message) {
     }
 
     if((status != TX_SUCCESS)) {
-        DEBUG_PRINTLN("ERROR: Failed to receive message from queue (Status: %d, Queue: %s).", status, queue->_TX_QUEUE.tx_queue_name);
+        DEBUG_PRINTLN("ERROR: Failed to receive message from queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }
 

--- a/Core/Src/u_queues.c
+++ b/Core/Src/u_queues.c
@@ -76,14 +76,14 @@ static uint8_t _create_queue(TX_BYTE_POOL *byte_pool, queue_t *queue) {
     /* Allocate the stack for the queue. */
     status = tx_byte_allocate(byte_pool, (VOID**) &pointer, queue_size_bytes, TX_NO_WAIT);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate memory before creating queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->name);
+        DEBUG_PRINTLN("ERROR: Failed to allocate memory before creating queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->name);
         return U_ERROR;
     }
 
     /* Create the queue */
     status = tx_queue_create(&queue->_TX_QUEUE, queue->name, message_size_words, pointer, queue_size_bytes);
     if (status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->name);
+        DEBUG_PRINTLN("ERROR: Failed to create queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->name);
         tx_byte_release(pointer); // Free allocated memory if queue creation fails
         return U_ERROR;
     }
@@ -121,7 +121,7 @@ uint8_t queue_send(queue_t *queue, void *message) {
     /* Send message (buffer) to the queue. */
     status = tx_queue_send(&queue->_TX_QUEUE, buffer, QUEUE_WAIT_TIME);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to send message to queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
+        DEBUG_PRINTLN("ERROR: Failed to send message to queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }
 
@@ -142,7 +142,7 @@ uint8_t  queue_receive(queue_t *queue, void *message) {
     }
 
     if((status != TX_SUCCESS)) {
-        DEBUG_PRINTLN("ERROR: Failed to receive message from queue (Status: %s, Queue: %s).", tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
+        DEBUG_PRINTLN("ERROR: Failed to receive message from queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
         return U_ERROR;
     }
 

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -188,14 +188,14 @@ static uint8_t _create_thread(TX_BYTE_POOL *byte_pool, thread_t *thread) {
     /* Allocate the stack for the thread. */
     status = tx_byte_allocate(byte_pool, (VOID**) &pointer, thread->size, TX_NO_WAIT);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate stack before creating thread (Status: %s, Thread: %s).", tx_status_toString(status), thread->name);
+        DEBUG_PRINTLN("ERROR: Failed to allocate stack before creating thread (Status: %d/%s, Thread: %s).", status, tx_status_toString(status), thread->name);
         return U_ERROR;
     }
 
     /* Create the thread. */
     status = tx_thread_create(&thread->_TX_THREAD, thread->name, thread->function, thread->thread_input, pointer, thread->size, thread->priority, thread->threshold, thread->time_slice, thread->auto_start);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create thread (Status: %s, Thread: %s).", tx_status_toString(status), thread->name);
+        DEBUG_PRINTLN("ERROR: Failed to create thread (Status: %d/%s, Thread: %s).", status, tx_status_toString(status), thread->name);
         tx_byte_release(pointer); // Free allocated memory if thread creation fails
         return U_ERROR;
     }

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -155,7 +155,7 @@ void shutdown_thread(ULONG thread_input) {
         /* Create bitstream. */
         bitstream_t bitstream;
         uint8_t bitstream_data[2];
-        bitstream_init(&bitstream, &bitstream_data, 2);
+        bitstream_init(&bitstream, bitstream_data, 2);
 
         /* Read the shutdown pins and add them to the bitstream. */
         bitstream_add(&bitstream, (HAL_GPIO_ReadPin(BMS_GPIO_GPIO_Port, BMS_GPIO_Pin) == GPIO_PIN_SET), 1);               // Read BMS_GPIO pin.
@@ -188,14 +188,14 @@ static uint8_t _create_thread(TX_BYTE_POOL *byte_pool, thread_t *thread) {
     /* Allocate the stack for the thread. */
     status = tx_byte_allocate(byte_pool, (VOID**) &pointer, thread->size, TX_NO_WAIT);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate stack before creating thread (Status: %d, Thread: %s).", status, thread->name);
+        DEBUG_PRINTLN("ERROR: Failed to allocate stack before creating thread (Status: %s, Thread: %s).", tx_status_toString(status), thread->name);
         return U_ERROR;
     }
 
     /* Create the thread. */
     status = tx_thread_create(&thread->_TX_THREAD, thread->name, thread->function, thread->thread_input, pointer, thread->size, thread->priority, thread->threshold, thread->time_slice, thread->auto_start);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create thread (Status: %d, Thread: %s).", status, thread->name);
+        DEBUG_PRINTLN("ERROR: Failed to create thread (Status: %s, Thread: %s).", tx_status_toString(status), thread->name);
         tx_byte_release(pointer); // Free allocated memory if thread creation fails
         return U_ERROR;
     }


### PR DESCRIPTION
Added three functions:
`tx_status_toString()`
`nx_status_toString()`
`hal_status_toString()`

These functions convert status macros to printable strings. They're intended to be used with `DEBUG_PRINTLN()` and probably shouldn't be used outside of debugging purposes.