### PR TITLE
Added a mutex for faults

### DIFF
--- a/Core/Inc/u_mutexes.h
+++ b/Core/Inc/u_mutexes.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 
 /* Mutex Config Macros */
-#define MUTEX_WAIT_TIME     MS_TO_TICKS(1000) // Wait time for mutex stuff before timing out
+#define MUTEX_WAIT_TIME TX_WAIT_FOREVER // Wait time for mutex stuff before timing out
 
 typedef struct {
     /* PUBLIC: Mutex Configuration Settings */

--- a/Core/Inc/u_mutexes.h
+++ b/Core/Inc/u_mutexes.h
@@ -2,8 +2,12 @@
 #define __U_MUTEX_H
 
 #include "tx_api.h"
+#include "u_general.h"
 #include <stdint.h>
 #include <stdbool.h>
+
+/* Mutex Config Macros */
+#define MUTEX_WAIT_TIME     MS_TO_TICKS(1000) // Wait time for mutex stuff before timing out
 
 typedef struct {
     /* PUBLIC: Mutex Configuration Settings */
@@ -17,12 +21,12 @@ typedef struct {
 } mutex_t;
 
 /* Mutex List */
-extern mutex_t template_mutex; // Template Mutex
+extern mutex_t faults_mutex; // Faults Mutex
 // add more as necessary...
 
 /* API */
 uint8_t mutexes_init(); // Initializes all mutexes set up in u_mutexes.c
-uint8_t mutex_get(mutex_t *mutex, ULONG wait_option); // Gets a mutex. wait_option can be TX_NO_WAIT, TX_WAIT_FOREVER, or a specific number of ticks.
+uint8_t mutex_get(mutex_t *mutex); // Gets a mutex.
 uint8_t mutex_put(mutex_t *mutex); // Puts a mutex.
 
 #endif /* u_mutex.h */

--- a/Core/Inc/u_queues.h
+++ b/Core/Inc/u_queues.h
@@ -13,7 +13,7 @@
 */
 
 /* Queue Config Macros */
-#define QUEUE_WAIT_TIME     MS_TO_TICKS(100) // Wait 100ms for queue stuff before timing out
+#define QUEUE_WAIT_TIME     MS_TO_TICKS(100) // Wait time for queue stuff before timing out
 
 typedef struct {
 

--- a/Core/Inc/u_queues.h
+++ b/Core/Inc/u_queues.h
@@ -13,7 +13,7 @@
 */
 
 /* Queue Config Macros */
-#define QUEUE_WAIT_TIME     MS_TO_TICKS(100) // Wait time for queue stuff before timing out
+#define QUEUE_WAIT_TIME TX_WAIT_FOREVER // Wait time for queue stuff before timing out
 
 typedef struct {
 

--- a/Core/Src/u_faults.c
+++ b/Core/Src/u_faults.c
@@ -55,20 +55,13 @@ static void _timer_callback(ULONG args) {
     /* Get faults mutex. */
     int status = mutex_get(&faults_mutex);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to get fault mutex. (Status: %d/%s, Relavent Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to get fault mutex. (Status: %d/%s, Relevant Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
         return;
     }
 
     /* Clear the fault. */
     fault_flags &= ~((uint64_t)(1 << fault_id));
     DEBUG_PRINTLN("UNFAULTED: %s.", faults[fault_id].name);
-
-    /* Put faults mutex. */
-    status = mutex_put(&faults_mutex);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to put faults mutex. (Status: %d/%s, Relavent Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
-        return;
-    }
 
     /* Check if there are any active critical faults. If not, unfault the car. */
     if((fault_flags & severity_mask) == 0) {
@@ -78,6 +71,13 @@ static void _timer_callback(ULONG args) {
         //      set_ready_mode();
         // }
         //
+    }
+
+    /* Put faults mutex. */
+    status = mutex_put(&faults_mutex);
+    if(status != TX_SUCCESS) {
+        DEBUG_PRINTLN("ERROR: Failed to put faults mutex. (Status: %d/%s, Relevant Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
+        return;
     }
 }
 
@@ -118,16 +118,16 @@ int trigger_fault(fault_t fault_id) {
     /* Get faults mutex. */
     int status = mutex_get(&faults_mutex);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to get fault mutex. (Status: %d/%s, Relavent Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to get fault mutex. (Status: %d/%s, Relevant Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 
-    fault_flags |= (uint64_t)(1 << fault_id); // Set the relavent fault bit.
+    fault_flags |= (uint64_t)(1 << fault_id); // Set the relevant fault bit.
 
     /* Put faults mutex. */
     status = mutex_put(&faults_mutex);
     if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to put faults mutex. (Status: %d/%s, Relavent Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
+        DEBUG_PRINTLN("ERROR: Failed to put faults mutex. (Status: %d/%s, Relevant Fault: %s).", status, tx_status_toString(status), faults[fault_id].name);
         return U_ERROR;
     }
 

--- a/Core/Src/u_mutexes.c
+++ b/Core/Src/u_mutexes.c
@@ -2,10 +2,10 @@
 #include "u_mutexes.h"
 #include "u_general.h"
 
-/* Template Mutex */
-/* only exists to show how to create mutexes (since there aren't any as of writing this. can be removed once an actual real mutex is set up here. */
-mutex_t template_mutex = {
-    .name = "Template Mutex",      /* Name of the mutex. */
+/* Faults Mutex */
+/* Used to protect multiple threads attempting to write to the fault flags variable at once. */
+mutex_t faults_mutex = {
+    .name = "Faults Mutex",        /* Name of the mutex. */
     .priority_inherit = TX_INHERIT /* Priority inheritance setting. */
 };
 
@@ -25,7 +25,7 @@ static uint8_t _create_mutex(mutex_t *mutex) {
 */
 uint8_t mutexes_init() {
     /* Create Mutexes. */
-    CATCH_ERROR(_create_mutex(&template_mutex), U_SUCCESS);  // Create Template Mutex.
+    CATCH_ERROR(_create_mutex(&faults_mutex), U_SUCCESS);  // Create Faults Mutex.
     // add more as necessary.
 
     DEBUG_PRINTLN("Ran mutexes_init().");
@@ -33,8 +33,8 @@ uint8_t mutexes_init() {
 }
 
 /* Get a mutex. */
-uint8_t mutex_get(mutex_t *mutex, ULONG wait_option) {
-    uint8_t status = tx_mutex_get(&mutex->_TX_MUTEX, wait_option);
+uint8_t mutex_get(mutex_t *mutex) {
+    uint8_t status = tx_mutex_get(&mutex->_TX_MUTEX, MUTEX_WAIT_TIME);
     if(status != TX_SUCCESS) {
         DEBUG_PRINTLN("ERROR: Failed to get mutex (Status: %d/%s, Mutex: %s).", status, tx_status_toString(status), mutex->name);
         return status;


### PR DESCRIPTION
Added a mutex (`faults_mutex`) meant to protect the faults flag list from being written to by multiple threads at the same time.