### PR TITLE
Updated ThreadX Files to use the Embedded-Base Utils

### DIFF
--- a/AZURE_RTOS/App/app_azure_rtos.c
+++ b/AZURE_RTOS/App/app_azure_rtos.c
@@ -22,7 +22,7 @@
 #include "app_azure_rtos.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-#include "u_general.h"
+#include "u_tx_debug.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,14 @@ target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE
 
 # Add sources to executable
 target_sources(${CMAKE_PROJECT_NAME} PRIVATE
-    # Embedded Base Stuff (drivers, middleware, utils, etc.)
+    # Embedded-Base ThreadX Utils
+    "../Drivers/Embedded-Base/threadX/src/u_tx_can.c"
+    "../Drivers/Embedded-Base/threadX/src/u_tx_debug.c"
+    "../Drivers/Embedded-Base/threadX/src/u_tx_mutex.c"
+    "../Drivers/Embedded-Base/threadX/src/u_tx_queues.c"
+    "../Drivers/Embedded-Base/threadX/src/u_tx_threads.c"
+
+    # Misc Embedded-Base Stuff (drivers, middleware, utils, etc.)
     "../Drivers/Embedded-Base/general/src/lan8670.c"
     "../Drivers/Embedded-Base/general/src/sht30.c"
     "../Drivers/Embedded-Base/general/src/lsm6dso_reg.c"
@@ -89,6 +96,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
     "./Drivers/Embedded-Base/general/include/"
     "./Drivers/Embedded-Base/middleware/include/"
     "./Drivers/Embedded-Base/platforms/stm32h563/include/"
+    "./Drivers/Embedded-Base/threadX/inc/"
     "./NetXDuo"
     "./Core/Inc/"
 )

--- a/Core/Inc/old_u_statemachine.h
+++ b/Core/Inc/old_u_statemachine.h
@@ -1,7 +1,7 @@
 #ifndef __STATEMACHINE_H
 #define __STATEMACHINE_H
 
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include <stdint.h>
 #include <stdio.h>
 

--- a/Core/Inc/u_ethernet.h
+++ b/Core/Inc/u_ethernet.h
@@ -2,6 +2,7 @@
 #define __U_ETHERNET_H
 
 #include "u_general.h"
+#include "u_tx_debug.h"
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/Core/Inc/u_general.h
+++ b/Core/Inc/u_general.h
@@ -6,46 +6,7 @@
 #include "tx_port.h"
 #include "stm32h5xx_hal.h"
 
-/* This file (and u_general.c) contain miscellaneous macros, functions, and configuration settings that can be used throughout the project. */
-
-/* General-purpose status macros. */
-#define U_SUCCESS     0
-#define U_ERROR       1
-#define U_QUEUE_EMPTY 2
-
-/* Debugging Macros */
-#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__) /* Gets the name of the file. */
-#define U_DEBUG /* Comment out to enable/disable debugging. */
-#ifdef U_DEBUG
-    #define DEBUG_PRINTLN(message, ...) printf("[%s/%s()] " message "\n", __FILENAME__, __func__, ##__VA_ARGS__) /* Prints an error message in the format: "[file_name.c/function()] {message}"*/
-#else
-    #define DEBUG_PRINTLN(message, ...) /* If debugging is turned off, macro doesn't need to expand to anything. */
-#endif
-
-/**
- * @brief Checks if a function is successful when called. DEBUG_PRINTLNs an error message if it fails.
- * @param function_call The function to call.
- * @param success The function's success code/macro (e.g., U_SUCCESS, TX_SUCCESS, etc.).
- * 
- * @note This macro intentionally doesn't support custom error messages, for the sake of readability. If an error is complex enough to 
- *       require a custom message, the error should probably be checked manually and DEBUG_PRINTLN() called directly.
- */
-#define CATCH_ERROR(function_call, success) do { \
-    int _function_status = (function_call); \
-    if (_function_status != success) { \
-        DEBUG_PRINTLN("CATCH_ERROR(): Function failed: %s (Status: %d)", #function_call, _function_status); \
-        return _function_status; \
-    } \
-} while(0)
-
-/* Time and tick conversions */
-#define MS_TO_TICKS(ms) (((ms) * TX_TIMER_TICKS_PER_SECOND + 999) / 1000)
-#define TICKS_TO_MS(ticks)  ((ticks) * 1000 / TX_TIMER_TICKS_PER_SECOND)
-
-/* These functions convert status macros to a printable string. */
-/* They are intended to be used with DEBUG_PRINTLN(), and shouldn't really be used outside of debugging purposes. */
-const char* tx_status_toString(UINT status); // Converts a ThreadX status macro to a printable string.
-const char* nx_status_toString(UINT status); // Converts a NetX status macro to a printable string.
-const char* hal_status_toString(HAL_StatusTypeDef status); // Converts a HAL status macro to a printable string.
+/* Converts a NetX status macro to a printable string. */
+const char* nx_status_toString(UINT status); // u_TODO - move this to embedded-base once a netX/ directory is made.
 
 #endif /* u_general.h */

--- a/Core/Inc/u_mutexes.h
+++ b/Core/Inc/u_mutexes.h
@@ -2,20 +2,10 @@
 #define __U_MUTEX_H
 
 #include "tx_api.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
+#include "u_tx_mutex.h"
 #include <stdint.h>
 #include <stdbool.h>
-
-typedef struct {
-    /* PUBLIC: Mutex Configuration Settings */
-    /* Set these when defining an instance of this struct. */
-    const CHAR *name;            /* Name of Mutex */
-    const UINT priority_inherit; /* Specifies if the mutex supports priority inheritance. See page 55 of the "Azure RTOS ThreadX User Guide". */
-
-    /* PRIVATE: Internal implementation - DO NOT ACCESS DIRECTLY */
-    /* (should only be accessed by functions in u_mutexes.c) */
-    TX_MUTEX _TX_MUTEX;
-} mutex_t;
 
 /* Mutex List */
 extern mutex_t faults_mutex;       // Faults Mutex
@@ -30,7 +20,5 @@ extern mutex_t adc2_mutex;         // ADC2 Mutex
 
 /* API */
 uint8_t mutexes_init(); // Initializes all mutexes set up in u_mutexes.c
-uint8_t mutex_get(mutex_t *mutex); // Gets a mutex.
-uint8_t mutex_put(mutex_t *mutex); // Puts a mutex.
 
 #endif /* u_mutex.h */

--- a/Core/Inc/u_queues.h
+++ b/Core/Inc/u_queues.h
@@ -2,7 +2,7 @@
 #define __U_QUEUES_H
 
 #include "tx_api.h"
-#include "u_general.h"
+#include "u_tx_queues.h"
 #include "u_ethernet.h"
 #include <stdint.h>
 
@@ -15,21 +15,6 @@
 /* Queue Config Macros */
 #define QUEUE_WAIT_TIME TX_NO_WAIT // Wait time for queue stuff before timing out
 
-typedef struct {
-
-    /* PUBLIC: Queue Configuration Settings */
-    /* Set these when defining an instance of this struct. */
-    const CHAR *name;        /* Name of the queue */
-    const UINT message_size; /* Size of each message in the queue, in bytes. */
-    const UINT capacity;     /* Maximum number of messages in the queue */
-
-    /* PRIVATE: Internal implementation - DO NOT ACCESS DIRECTLY */
-    /* (should only be accessed by functions in u_queues.c) */
-    TX_QUEUE _TX_QUEUE;      /* Queue instance. */
-    size_t   _bytes;         /* Size of each queue message, in bytes. */
-    size_t   _words;         /* Size of each queue message, in 32-bit words. */
-} queue_t;
-
 /* Queue List */
 extern queue_t eth_incoming; // Incoming Ethernet Queue
 extern queue_t eth_outgoing; // Outgoing Ethernet Queue
@@ -41,7 +26,5 @@ extern queue_t state_transition_queue; // State Transition Queue
 
 /* API */
 uint8_t queues_init(TX_BYTE_POOL *byte_pool); // Initializes all queues. Called from app_threadx.c
-uint8_t queue_send(queue_t *queue, void *message); // Sends a message to the specified queue.
-uint8_t queue_receive(queue_t *queue, void *message); // Receives a message from the specified queue.
 
 #endif /* u_queues.h */

--- a/Core/Inc/u_threads.h
+++ b/Core/Inc/u_threads.h
@@ -2,6 +2,7 @@
 #define __U_THREADS_H
 
 #include "tx_api.h"
+#include "u_tx_threads.h"
 #include <stdint.h>
 #include <stdio.h>
 
@@ -13,24 +14,6 @@
 
 /* Initializes all threads. Called from app_threadx.c */
 uint8_t threads_init(TX_BYTE_POOL *byte_pool);
-
-typedef struct {
-    /* PUBLIC: Thread Configuration Settings */
-    /* Set these when defining an instance of this struct. */
-    const CHAR      *name;                /* Name of Thread */
-    const ULONG     thread_input;         /* Thread Input. You can put whatever you want in here. Defaults to zero. */
-    const ULONG     size;                 /* Stack Size (in bytes) */
-    const UINT      priority;             /* Priority */
-    const UINT      threshold;            /* Preemption Threshold */
-    const ULONG     time_slice;           /* Time Slice */
-    const UINT      auto_start;           /* Auto Start */
-    const UINT      sleep;                /* Sleep (in ticks) */
-    VOID            (*function)(ULONG);   /* Thread Function */
-
-    /* PRIVATE: Internal implementation - DO NOT ACCESS DIRECTLY */
-    /* (should only be accessed by functions in u_threads.c) */
-    TX_THREAD _TX_THREAD;
-} thread_t;
 
 /* Thread Functions */
 void default_thread(ULONG thread_input);

--- a/Core/Inc/u_threads.h
+++ b/Core/Inc/u_threads.h
@@ -2,7 +2,6 @@
 #define __U_THREADS_H
 
 #include "tx_api.h"
-#include "u_general.h"
 #include <stdint.h>
 #include <stdio.h>
 

--- a/Core/Src/u_adc.c
+++ b/Core/Src/u_adc.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
+#include "u_tx_debug.h"
 #include "main.h"
 #include "u_mutexes.h"
-#include "u_general.h"
 #include "u_adc.h"
 
 /* ADC1 Config. */

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include "u_can.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "stm32h5xx_hal.h"
 
 

--- a/Core/Src/u_efuses.c
+++ b/Core/Src/u_efuses.c
@@ -1,5 +1,5 @@
 #include "u_efuses.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "u_adc.h"
 
 /* TPS1663x (eFuse) datasheet: https://www.ti.com/lit/ds/symlink/tps1663.pdf?ts=1756438634613 */

--- a/Core/Src/u_faults.c
+++ b/Core/Src/u_faults.c
@@ -3,7 +3,7 @@
 #include "main.h"
 #include "u_faults.h"
 #include "u_statemachine.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "u_mutexes.h"
 
 typedef enum {

--- a/Core/Src/u_general.c
+++ b/Core/Src/u_general.c
@@ -4,51 +4,6 @@
 #include "stm32h5xx_hal.h"
 #include <stdio.h>
 
-/* Converts a ThreadX status macro to a printable string. */
-/* This function is intended to be used with DEBUG_PRINTLN(), and shouldn't really ever be used outside of debugging purposes. */
-/* (these macros are defined in tx_api.h) */
-const char* tx_status_toString(UINT status) {
-    switch(status) {
-        case TX_SUCCESS: return "TX_SUCCESS";
-        case TX_DELETED: return "TX_DELETED";
-        case TX_POOL_ERROR: return "TX_POOL_ERROR";
-        case TX_PTR_ERROR: return "TX_PTR_ERROR";
-        case TX_WAIT_ERROR: return "TX_WAIT_ERROR";
-        case TX_SIZE_ERROR: return "TX_SIZE_ERROR";
-        case TX_GROUP_ERROR: return "TX_GROUP_ERROR";
-        case TX_NO_EVENTS: return "TX_NO_EVENTS";
-        case TX_OPTION_ERROR: return "TX_OPTION_ERROR";
-        case TX_QUEUE_ERROR: return "TX_QUEUE_ERROR";
-        case TX_QUEUE_EMPTY: return "TX_QUEUE_EMPTY";
-        case TX_QUEUE_FULL: return "TX_QUEUE_FULL";
-        case TX_SEMAPHORE_ERROR: return "TX_SEMAPHORE_ERROR";
-        case TX_NO_INSTANCE: return "TX_NO_INSTANCE";
-        case TX_THREAD_ERROR: return "TX_THREAD_ERROR";
-        case TX_PRIORITY_ERROR: return "TX_PRIORITY_ERROR";
-        case TX_NO_MEMORY: return "TX_NO_MEMORY"; // Same as TX_START_ERROR
-        case TX_DELETE_ERROR: return "TX_DELETE_ERROR";
-        case TX_RESUME_ERROR: return "TX_RESUME_ERROR";
-        case TX_CALLER_ERROR: return "TX_CALLER_ERROR";
-        case TX_SUSPEND_ERROR: return "TX_SUSPEND_ERROR";
-        case TX_TIMER_ERROR: return "TX_TIMER_ERROR";
-        case TX_TICK_ERROR: return "TX_TICK_ERROR";
-        case TX_ACTIVATE_ERROR: return "TX_ACTIVATE_ERROR";
-        case TX_THRESH_ERROR: return "TX_THRESH_ERROR";
-        case TX_SUSPEND_LIFTED: return "TX_SUSPEND_LIFTED";
-        case TX_WAIT_ABORTED: return "TX_WAIT_ABORTED";
-        case TX_WAIT_ABORT_ERROR: return "TX_WAIT_ABORT_ERROR";
-        case TX_MUTEX_ERROR: return "TX_MUTEX_ERROR";
-        case TX_NOT_AVAILABLE: return "TX_NOT_AVAILABLE";
-        case TX_NOT_OWNED: return "TX_NOT_OWNED";
-        case TX_INHERIT_ERROR: return "TX_INHERIT_ERROR";
-        case TX_NOT_DONE: return "TX_NOT_DONE";
-        case TX_CEILING_EXCEEDED: return "TX_CEILING_EXCEEDED";
-        case TX_INVALID_CEILING: return "TX_INVALID_CEILING";
-        case TX_FEATURE_NOT_ENABLED: return "TX_FEATURE_NOT_ENABLED";
-        default: return "UNKNOWN_STATUS";
-    }
-}
-
 /* Converts a NetX status macro to a printable string. */
 /* This function is intended to be used with DEBUG_PRINTLN(), and shouldn't really ever be used outside of debugging purposes. */
 /* (these macros are defined in nx_api.h) */
@@ -119,19 +74,6 @@ const char* nx_status_toString(UINT status) {
         case NX_OPTION_HEADER_ERROR: return "NX_OPTION_HEADER_ERROR";
         case NX_CONTINUE: return "NX_CONTINUE";
         case NX_TCPIP_OFFLOAD_ERROR: return "NX_TCPIP_OFFLOAD_ERROR";
-        default: return "UNKNOWN_STATUS";
-    }
-}
-
-/* Converts a STM32 HAL status macro to a printable string. */
-/* This function is intended to be used with DEBUG_PRINTLN(), and shouldn't really ever be used outside of debugging purposes. */
-/* (these macros are defined in stm32h5xx_hal_def.h) */
-const char* hal_status_toString(HAL_StatusTypeDef status) {
-    switch(status) {
-        case HAL_OK: return "HAL_OK";
-        case HAL_ERROR: return "HAL_ERROR";
-        case HAL_BUSY: return "HAL_BUSY";
-        case HAL_TIMEOUT: return "HAL_TIMEOUT";
         default: return "UNKNOWN_STATUS";
     }
 }

--- a/Core/Src/u_inbox.c
+++ b/Core/Src/u_inbox.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include "fdcan.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "u_ethernet.h"
 #include "u_can.h"
 #include "u_bms.h"

--- a/Core/Src/u_mutexes.c
+++ b/Core/Src/u_mutexes.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "u_mutexes.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 
 /* Faults Mutex */
 /* Used to protect multiple threads attempting to write to the fault flags variable at once. */
@@ -51,55 +51,22 @@ mutex_t adc2_mutex = {
     .priority_inherit = TX_INHERIT /* Priority inheritance setting. */
 };
 
-/* Helper function. Creates a ThreadX mutex. */
-static uint8_t _create_mutex(mutex_t *mutex) {
-    uint8_t status = tx_mutex_create(&mutex->_TX_MUTEX, (CHAR*)mutex->name, mutex->priority_inherit);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create mutex (Status: %d/%s, Name: %s).", status, tx_status_toString(status), mutex->name);
-        return status;
-    }
-
-    return U_SUCCESS;
-}
-
 /* Initializes all ThreadX mutexes. 
 *  Calls to _create_mutex() should go in here
 */
 uint8_t mutexes_init() {
     /* Create Mutexes. */
-    CATCH_ERROR(_create_mutex(&faults_mutex), U_SUCCESS);       // Create Faults Mutex.
-    CATCH_ERROR(_create_mutex(&brake_state_mutex), U_SUCCESS);  // Create Brake State Mutex.
-    CATCH_ERROR(_create_mutex(&pedal_data_mutex), U_SUCCESS);   // Create Pedal Data Mutex.
-    CATCH_ERROR(_create_mutex(&bms_mutex), U_SUCCESS);          // Create BMS Mutex.
-    CATCH_ERROR(_create_mutex(&torque_limit_mutex), U_SUCCESS); // Create Torque Limit Mutex.
-    CATCH_ERROR(_create_mutex(&dti_mutex), U_SUCCESS);          // Create DTI Mutex.
-    CATCH_ERROR(_create_mutex(&adc1_mutex), U_SUCCESS);         // Create ADC1 Mutex.
-    CATCH_ERROR(_create_mutex(&adc2_mutex), U_SUCCESS);         // Create ADC2 Mutex.
+    CATCH_ERROR(create_mutex(&faults_mutex), U_SUCCESS);       // Create Faults Mutex.
+    CATCH_ERROR(create_mutex(&brake_state_mutex), U_SUCCESS);  // Create Brake State Mutex.
+    CATCH_ERROR(create_mutex(&pedal_data_mutex), U_SUCCESS);   // Create Pedal Data Mutex.
+    CATCH_ERROR(create_mutex(&bms_mutex), U_SUCCESS);          // Create BMS Mutex.
+    CATCH_ERROR(create_mutex(&torque_limit_mutex), U_SUCCESS); // Create Torque Limit Mutex.
+    CATCH_ERROR(create_mutex(&dti_mutex), U_SUCCESS);          // Create DTI Mutex.
+    CATCH_ERROR(create_mutex(&adc1_mutex), U_SUCCESS);         // Create ADC1 Mutex.
+    CATCH_ERROR(create_mutex(&adc2_mutex), U_SUCCESS);         // Create ADC2 Mutex.
 
     // add more as necessary.
 
     DEBUG_PRINTLN("Ran mutexes_init().");
-    return U_SUCCESS;
-}
-
-/* Get a mutex. */
-uint8_t mutex_get(mutex_t *mutex) {
-    uint8_t status = tx_mutex_get(&mutex->_TX_MUTEX, TX_WAIT_FOREVER);
-    if(status != TX_SUCCESS) { // Note: As long as TX_WAIT_FOREVER is used, tx_mutex_get() should never be unsucessful here (since it waits indefinitely until the mutex is available).
-        DEBUG_PRINTLN("ERROR: Failed to get mutex (Status: %d/%s, Mutex: %s).", status, tx_status_toString(status), mutex->name);
-        return status;
-    }
-
-    return U_SUCCESS;
-}
-
-/* Put a mutex. */
-uint8_t mutex_put(mutex_t *mutex) {
-    uint8_t status = tx_mutex_put(&mutex->_TX_MUTEX);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to put mutex (Status: %d/%s, Mutex: %s).", status, tx_status_toString(status), mutex->name);
-        return status;
-    }
-
     return U_SUCCESS;
 }

--- a/Core/Src/u_pedals.c
+++ b/Core/Src/u_pedals.c
@@ -8,7 +8,7 @@
 #include "u_queues.h"
 #include "u_mutexes.h"
 #include "u_faults.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "u_efuses.h"
 #include "u_dti.h"
 #include "u_statemachine.h"

--- a/Core/Src/u_peripherals.c
+++ b/Core/Src/u_peripherals.c
@@ -1,7 +1,7 @@
 #include "sht30.h"
+#include "u_tx_debug.h"
 #include "main.h"
 #include "u_peripherals.h"
-#include "u_general.h"
 
 /* Driver instances. */
 static sht30_t temperature_sensor = { .dev_address = SHT30_I2C_ADDR };

--- a/Core/Src/u_queues.c
+++ b/Core/Src/u_queues.c
@@ -1,21 +1,9 @@
 #include "u_queues.h"
 #include "u_can.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "u_faults.h"
 #include "u_statemachine.h"
 #include <stdio.h>
-
-/* 
-*  NOTE: This file is kinda weird because of how ThreadX queues work. The size of each message in a ThreadX queue has to be a multiple of 4 bytes, since ThreadX
-*  queues are implemented as arrays of 32-bit words. So, to create queues for structs that aren't a multiple of 4 bytes, you have to round up to the nearest multiple of 4 bytes.
-*  This is handled in the _create_queue() function below.
-*
-*  Then, the queue_send() and queue_receive() functions use a buffer to send/receive messages to/from the queue.
-*  This handles any conversions between the actual message size and the rounded-up size.
-*
-*  On the bright side (assuming my code works), this file should automatically handle all the 32-bit word stuff for you so you don't have to worry about it.
-*
-*/
 
 /* Incoming Ethernet Queue */
 queue_t eth_incoming = {
@@ -59,103 +47,19 @@ queue_t state_transition_queue = {
     .capacity = 10                         /* Number of messages the queue can hold. */
 };
 
-/* Helper function. Creates a ThreadX queue. */
-static uint8_t _create_queue(TX_BYTE_POOL *byte_pool, queue_t *queue) {
-    uint8_t status;
-    void *pointer;
-
-    /* Calculate message size in 32-bit words (round up), and then validate it. */
-    /* According to the Azure RTOS ThreadX Docs, "message sizes range from 1 32-bit word to 16 32-bit words". */
-    /* Basically, queue messages have to be a multiple of 4 bytes? Kinda weird but this should handle it. */
-    UINT message_size_words = (queue->message_size + 3) / 4;
-    if (message_size_words < 1 || message_size_words > 16) {
-        DEBUG_PRINTLN("ERROR: Invalid message size %d bytes (must be 1-64 bytes). Queue: %s", queue->message_size, queue->name);
-        return U_ERROR;
-    }
-
-    /* Store metadata */
-    queue->_bytes = queue->message_size;
-    queue->_words = message_size_words;
-
-    /* Calculate total queue size in bytes. */
-    int queue_size_bytes = message_size_words * 4 * queue->capacity;
-
-    /* Allocate the stack for the queue. */
-    status = tx_byte_allocate(byte_pool, (VOID**) &pointer, queue_size_bytes, TX_NO_WAIT);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate memory before creating queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->name);
-        return U_ERROR;
-    }
-
-    /* Create the queue */
-    status = tx_queue_create(&queue->_TX_QUEUE, (CHAR*)queue->name, message_size_words, pointer, queue_size_bytes);
-    if (status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->name);
-        tx_byte_release(pointer); // Free allocated memory if queue creation fails
-        return U_ERROR;
-    }
-
-    return U_SUCCESS;
-
-}
-
 /* Initializes all ThreadX queues. 
 *  Calls to _create_queue() should go in here
 */
 uint8_t queues_init(TX_BYTE_POOL *byte_pool) {
 
     /* Create Queues */
-    CATCH_ERROR(_create_queue(byte_pool, &eth_incoming), U_SUCCESS); // Create Incoming Ethernet Queue
-    CATCH_ERROR(_create_queue(byte_pool, &eth_outgoing), U_SUCCESS); // Create Outgoing Ethernet Queue
-    CATCH_ERROR(_create_queue(byte_pool, &can_incoming), U_SUCCESS); // Create Incoming CAN Queue
-    CATCH_ERROR(_create_queue(byte_pool, &can_outgoing), U_SUCCESS); // Create Outgoing CAN Queue
-    CATCH_ERROR(_create_queue(byte_pool, &faults), U_SUCCESS);       // Create Faults Queue
-    CATCH_ERROR(_create_queue(byte_pool, &state_transition_queue), U_SUCCESS); // Create state transition queue.
+    CATCH_ERROR(create_queue(byte_pool, &eth_incoming), U_SUCCESS); // Create Incoming Ethernet Queue
+    CATCH_ERROR(create_queue(byte_pool, &eth_outgoing), U_SUCCESS); // Create Outgoing Ethernet Queue
+    CATCH_ERROR(create_queue(byte_pool, &can_incoming), U_SUCCESS); // Create Incoming CAN Queue
+    CATCH_ERROR(create_queue(byte_pool, &can_outgoing), U_SUCCESS); // Create Outgoing CAN Queue
+    CATCH_ERROR(create_queue(byte_pool, &faults), U_SUCCESS);       // Create Faults Queue
+    CATCH_ERROR(create_queue(byte_pool, &state_transition_queue), U_SUCCESS); // Create state transition queue.
 
     DEBUG_PRINTLN("Ran queues_init().");
-    return U_SUCCESS;
-}
-
-uint8_t queue_send(queue_t *queue, void *message) {
-    UINT status;
-
-    /* Create a buffer. */
-    uint32_t buffer[queue->_words];    // Max size is 16 words (64 bytes).
-    memset(buffer, 0, sizeof(buffer)); // Initialize buffer to zero
-
-    /* Copy message into the buffer. The buffer is what actually gets sent to the queue. */
-    memcpy(buffer, message, queue->_bytes);
-
-    /* Send message (buffer) to the queue. */
-    status = tx_queue_send(&queue->_TX_QUEUE, buffer, QUEUE_WAIT_TIME);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to send message to queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
-        return U_ERROR;
-    }
-
-    return U_SUCCESS;
-}
-
-uint8_t  queue_receive(queue_t *queue, void *message) {
-    UINT status;
-
-    /* Create a buffer */
-    uint32_t buffer[queue->_words];     // Max size is 16 words (64 bytes).
-    memset(buffer, 0, sizeof(buffer)); // Initialize buffer to zero
-
-    /* Receive message from the queue. */
-    status = tx_queue_receive(&queue->_TX_QUEUE, buffer, QUEUE_WAIT_TIME);
-    if(status == TX_QUEUE_EMPTY) {
-        return U_QUEUE_EMPTY;
-    }
-
-    if((status != TX_SUCCESS)) {
-        DEBUG_PRINTLN("ERROR: Failed to receive message from queue (Status: %d/%s, Queue: %s).", status, tx_status_toString(status), queue->_TX_QUEUE.tx_queue_name);
-        return U_ERROR;
-    }
-
-    /* Copy the data from the buffer into the message pointer. Using memcpy() here prevents memory overflow. */
-    memcpy(message, buffer, queue->_bytes);
-
     return U_SUCCESS;
 }

--- a/Core/Src/u_rtds.c
+++ b/Core/Src/u_rtds.c
@@ -1,7 +1,7 @@
 #include "tx_api.h"
 #include "main.h"
 #include "u_rtds.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 
 static TX_TIMER rtds_timer; /* Timer for the RTDS. */
 static TX_TIMER reverse_sound_timer; /* Timer for the reverse sound beeping. */

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -11,7 +11,7 @@
 #include "u_pedals.h"
 #include "u_can.h"
 #include "u_rtds.h"
-#include "u_general.h"
+#include "u_tx_debug.h"
 #include "u_queues.h"
 #include "u_faults.h"
 #include "u_pedals.h"

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -1,4 +1,5 @@
 #include "main.h"
+#include "u_tx_debug.h"
 #include "u_threads.h"
 #include "u_queues.h"
 #include "u_inbox.h"

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -319,43 +319,20 @@ void efuse_thread(ULONG thread_input) {
     }
 }
 
-/* Helper function. Creates a ThreadX thread. */
-static uint8_t _create_thread(TX_BYTE_POOL *byte_pool, thread_t *thread) {
-    CHAR *pointer;
-    uint8_t status;
-
-    /* Allocate the stack for the thread. */
-    status = tx_byte_allocate(byte_pool, (VOID**) &pointer, thread->size, TX_NO_WAIT);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to allocate stack before creating thread (Status: %d/%s, Thread: %s).", status, tx_status_toString(status), thread->name);
-        return U_ERROR;
-    }
-
-    /* Create the thread. */
-    status = tx_thread_create(&thread->_TX_THREAD, (CHAR*)thread->name, thread->function, thread->thread_input, pointer, thread->size, thread->priority, thread->threshold, thread->time_slice, thread->auto_start);
-    if(status != TX_SUCCESS) {
-        DEBUG_PRINTLN("ERROR: Failed to create thread (Status: %d/%s, Thread: %s).", status, tx_status_toString(status), thread->name);
-        tx_byte_release(pointer); // Free allocated memory if thread creation fails
-        return U_ERROR;
-    }
-    
-    return U_SUCCESS;
-}
-
 /* Initializes all ThreadX threads. 
 *  Calls to _create_thread() should go in here
 */
 uint8_t threads_init(TX_BYTE_POOL *byte_pool) {
 
     /* Create Threads */
-    CATCH_ERROR(_create_thread(byte_pool, &_default_thread), U_SUCCESS);      // Create Default thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_ethernet_thread), U_SUCCESS);     // Create Ethernet thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_can_thread), U_SUCCESS);          // Create CAN thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_faults_thread), U_SUCCESS);       // Create Faults thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_shutdown_thread), U_SUCCESS);     // Create Shutdown thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_statemachine_thread), U_SUCCESS); // Create State Machine thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_pedals_thread), U_SUCCESS);       // Create Pedals thread.
-    CATCH_ERROR(_create_thread(byte_pool, &_efuse_thread), U_SUCCESS);        // Create eFuse thread.
+    CATCH_ERROR(create_thread(byte_pool, &_default_thread), U_SUCCESS);      // Create Default thread.
+    CATCH_ERROR(create_thread(byte_pool, &_ethernet_thread), U_SUCCESS);     // Create Ethernet thread.
+    CATCH_ERROR(create_thread(byte_pool, &_can_thread), U_SUCCESS);          // Create CAN thread.
+    CATCH_ERROR(create_thread(byte_pool, &_faults_thread), U_SUCCESS);       // Create Faults thread.
+    CATCH_ERROR(create_thread(byte_pool, &_shutdown_thread), U_SUCCESS);     // Create Shutdown thread.
+    CATCH_ERROR(create_thread(byte_pool, &_statemachine_thread), U_SUCCESS); // Create State Machine thread.
+    CATCH_ERROR(create_thread(byte_pool, &_pedals_thread), U_SUCCESS);       // Create Pedals thread.
+    CATCH_ERROR(create_thread(byte_pool, &_efuse_thread), U_SUCCESS);        // Create eFuse thread.
 
     // add more threads here if need
 


### PR DESCRIPTION
Most of the ThreadX utils in this repo (i.e. _create_thread(), _create_queue(), _create_mutex(), thread_t, queue_t, mutex_t, and other stuff like that) was moved to the `threadX/` directory in Embedded-Base. This PR removes any redundant code in this repo now that those utils have moved.