### PR TITLE
Change eFuse Thread Priority

### DIFF
--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -232,11 +232,11 @@ void pedals_thread(ULONG thread_input) {
 static thread_t _efuse_thread = {
         .name       = "eFuse Thread",         /* Name */
         .size       = 512,                    /* Stack Size (in bytes) */
-        .priority   = 2,                      /* Priority */
+        .priority   = 10,                     /* Priority */
         .threshold  = 0,                      /* Preemption Threshold */
         .time_slice = TX_NO_TIME_SLICE,       /* Time Slice */
         .auto_start = TX_AUTO_START,          /* Auto Start */
-        .sleep      = 1,                      /* Sleep (in ticks) */
+        .sleep      = 10,                     /* Sleep (in ticks) */
         .function   = efuse_thread            /* Thread Function */
     };
 void efuse_thread(ULONG thread_input) {


### PR DESCRIPTION
Changed eFuse thread sleep from 1 tick to 10 ticks, and priority from 2 to 10. Pretty sure the old config would've spammed the CAN outgoing queue.