### PR TITLE
Removed ADC memcpy()

### DIFF
--- a/Core/Src/u_adc.c
+++ b/Core/Src/u_adc.c
@@ -148,7 +148,7 @@ raw_efuse_adc_t adc_getEFuseData(void) {
 
 /* Get raw pedal sensor ADC Data. */
 raw_pedal_adc_t adc_getPedalData(void) {
-    raw_pedal_adc_t sensors;
+    raw_pedal_adc_t sensors = { 0 };
 
     mutex_get(&adc_mutex);
     sensors.data[PEDAL_ACCEL1] = _adc1_buffer[ADC1_CHANNEL2];


### PR DESCRIPTION
Removed the `memcpy()` calls in `u_adc.c`, since they seemed inefficient. They were originally added to protect the ADC buffers from getting modified by DMA while they are being read, but if that ends up being a problem, I imagine implementing double buffering would make much more sense than using `memcpy()` and local buffers.

Closes #91 