### PR TITLE
Added ADC reading for the LFIU current sensors

### DIFF
--- a/Core/Inc/u_adc.h
+++ b/Core/Inc/u_adc.h
@@ -19,4 +19,8 @@ raw_efuse_adc_t adc_getEFuseData(void);
 typedef struct { uint16_t data[NUM_PEDALS]; } raw_pedal_adc_t; // Struct to store the data.
 raw_pedal_adc_t adc_getPedalData(void);
 
+/* Get LFIU sensor ADC data. */
+typedef struct { uint16_t data[NUM_LFIU]; } raw_lfiu_adc_t; // Struct to store the data.
+raw_lfiu_adc_t adc_getLfiuData(void);
+
 #endif /* u_adc.h */

--- a/Core/Inc/u_pedals.h
+++ b/Core/Inc/u_pedals.h
@@ -12,6 +12,15 @@ typedef enum {
     NUM_PEDALS
 } pedal_t;
 
+/* LFIU Sensors. */
+typedef enum {
+    LFIU_1,     /* LFIU Current Sensor 1. */
+    LFIU_2,     /* LFIU Current Sensor 2. */
+
+    /* Total number of LFIU current sensors. */
+    NUM_LFIU
+} lfiu_t;
+
 /* API */
 int pedals_init(void);                                  // Initializes Pedals ADC and creates pedal data timer.
 void pedals_process(void);                              // Pedal Processing Function. Meant to be called by the pedals thread.

--- a/Core/Src/u_adc.c
+++ b/Core/Src/u_adc.c
@@ -159,3 +159,15 @@ raw_pedal_adc_t adc_getPedalData(void) {
 
     return sensors;
 }
+
+/* Get raw LFIU sensor ADC Data. */
+raw_lfiu_adc_t adc_getLfiuData(void) {
+    raw_lfiu_adc_t sensors = { 0 };
+
+    mutex_get(&adc_mutex);
+    sensors.data[LFIU_1] = _mux_buffer[SEL2_HIGH];
+    sensors.data[LFIU_2] = _mux_buffer[SEL2_LOW];
+    mutex_put(&adc_mutex);
+
+    return sensors;
+}


### PR DESCRIPTION
Added a `raw_lfiu_adc_t` struct and a `adc_getLfiuData()` function to `u_adc.c`. Allows you to read the raw ADC data of the two LFIU current sensors. This PR doesn't actually convert the readings to current or do anything with the data though. That should probably happen in a dedicated file.

Closes #92 