### PR TITLE
Disable RTDS if BMS is Indicating a Shutdown

### DIFF
--- a/Core/Inc/u_statemachine.h
+++ b/Core/Inc/u_statemachine.h
@@ -135,7 +135,7 @@ void send_carstate_msg(void);
 
 /* BMS-Reported Shutdown! */
 void update_shutdown(bool new_shutdown);
-bool get_shutdown(void);
+bool is_shutdown_active(void);
 
 /* Process the state machine */
 void statemachine_process(state_req_t new_state_req);

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -238,6 +238,7 @@ void can_inbox(can_msg_t *message) {
         /* If shutdown is active, cancel the RTDS sound if it's active. */
         if(bms.shutdown == true) {
             rtds_cancelRTDS();
+            rtds_stopReverseSound();
         }
         break;
     default:

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -234,6 +234,11 @@ void can_inbox(can_msg_t *message) {
         shutdown_as_read_by_bms_t bms = { 0 };
         receive_shutdown_as_read_by_bms(message, &bms);
         update_shutdown(bms.shutdown);
+
+        /* If shutdown is active, cancel the RTDS sound if it's active. */
+        if(bms.shutdown == true) {
+            rtds_cancelRTDS();
+        }
         break;
     default:
         PRINTLN_WARNING("Unknown CAN Message Recieved (Message ID: 0x%X).", message->id);

--- a/Core/Src/u_rtds.c
+++ b/Core/Src/u_rtds.c
@@ -32,7 +32,7 @@ static timer_t reverse_sound_timer = {
 /* Sets (i.e. turns on) the RTDS pin. */
 static void _set_rtds_pin(void) {
     /* If shutdown is active, make it impossible to sound RTDS. */
-    if(get_shutdown() == true) {
+    if(is_shutdown_active() == true) {
         return; // Return early. Never ever have RTDS be high when shutdown is active.
     }
 

--- a/Core/Src/u_rtds.c
+++ b/Core/Src/u_rtds.c
@@ -3,6 +3,7 @@
 #include "u_tx_timers.h"
 #include "u_rtds.h"
 #include "u_queues.h"
+#include "u_statemachine.h"
 #include "u_faults.h"
 #include "u_tx_debug.h"
 
@@ -30,6 +31,11 @@ static timer_t reverse_sound_timer = {
 
 /* Sets (i.e. turns on) the RTDS pin. */
 static void _set_rtds_pin(void) {
+    /* If shutdown is active, make it impossible to sound RTDS. */
+    if(get_shutdown() == true) {
+        return; // Return early. Never ever have RTDS be high when shutdown is active.
+    }
+
     HAL_GPIO_WritePin(RTDS_GPIO_GPIO_Port, RTDS_GPIO_Pin, GPIO_PIN_SET); // Turn on RTDS pin.
     PRINTLN_INFO("Turned on RTDS pin.");
 }

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -54,7 +54,7 @@ void send_carstate_msg(void)
 		get_nero_state().home_mode,
 		get_nero_state().nero_index,
 		dti_get_mph(),
-		get_shutdown(),
+		is_shutdown_active(),
 		pedals_getTorqueLimitPercentage(),
 		(cerberus_state.functional != F_REVERSE),
 		pedals_getRegenLimit(),
@@ -68,7 +68,7 @@ void update_shutdown(bool new_shutdown) {
 	shutdown = new_shutdown;
 }
 
-bool get_shutdown(void) {
+bool is_shutdown_active(void) {
 	return shutdown;
 }
 
@@ -136,7 +136,7 @@ static int transition_functional_state(func_state_t new_state)
 
 		brake_state = pedals_getBrakeState();
 #ifdef TSMS_OVERRIDE
-		if (get_shutdown() && (!brake_state || cerberus_state.functional == FAULTED)) { // only enforce brake / fault if tsms is actually on
+		if (!is_shutdown_active() && (!brake_state || cerberus_state.functional == FAULTED)) { // only enforce brake / fault if tsms is actually on
 			return 3;
 		}
 		printf("Ignoring tsms\n\n");
@@ -151,13 +151,13 @@ static int transition_functional_state(func_state_t new_state)
 			return 3;
 		}
 
-		/* Only turn on motor if brakes engaged and tsms is on */
-		if (!brake_state || !get_shutdown()) {
+		/* Only turn on motor if brakes engaged and no shutdown active */
+		if (!brake_state || is_shutdown_active()) {
 			return 3;
 		}
 #endif
 
-		if (get_shutdown()) {
+		if (!is_shutdown_active()) {
 			rtds_soundRTDS();
 		}
 
@@ -200,7 +200,7 @@ static int transition_nero_state(nero_state_t new_state)
 		/* TSMS OFF and MPH = 0 to enter games */
 		if (new_state.nero_index == GAMES) {
 #ifndef TSMS_OVERRIDE
-			if (get_shutdown() || dti_get_mph() >= 1) {
+			if (!is_shutdown_active() || dti_get_mph() >= 1) {
 				return 1;
 			}
 #endif
@@ -330,21 +330,21 @@ void statemachine_process(state_req_t new_state_req) {
 		else if(new_state_req.id == FUNCTIONAL) { transition_functional_state(new_state_req.state.functional); }
 	}
 
-	if (!is_ts_rising && get_shutdown()) {
+	if (!is_ts_rising && !is_shutdown_active()) {
 		is_ts_rising = true;
 
 		/* Restart TS Rising timer. */
 		int status = timer_restart(&ts_rising_timer);
 		if(status != U_SUCCESS) {
-			PRINTLN_ERROR("Failed to restart TS Rising timer (in !ts_rising && get_shutdown()) (Status: %d).", status);
+			PRINTLN_ERROR("Failed to restart TS Rising timer (in !ts_rising && !is_shutdown_active()) (Status: %d).", status);
 			return;
 		}
 
-	} else if (!get_shutdown()) {
+	} else if (is_shutdown_active()) {
 		/* Stop the TS Rising timer. */
     	int status = timer_stop(&ts_rising_timer);
     	if(status != U_SUCCESS) {
-        	PRINTLN_ERROR("Failed to stop TS Rising timer (in !get_shutdown()) (Status: %d).", status);
+        	PRINTLN_ERROR("Failed to stop TS Rising timer (in is_shutdown_active()) (Status: %d).", status);
         	return;
     	}
 		is_ts_rising = false;

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -406,7 +406,7 @@ void vShutdown(ULONG thread_input) {
                                 || hv_c || hvd_gpio || imd_gpio || ckpt_gpio
                                 || inertia_sw_gpio || tsms_gpio;
 
-        if (shutdown_active && get_shutdown() == true) { // if tsms is still on when shutdown is active, trigger fault
+        if (shutdown_active || (get_shutdown() == true)) { // if tsms is still on when shutdown is active, trigger fault
             queue_send(&faults, &(fault_t){SHUTDOWN_FAULT}, TX_NO_WAIT);
         }
 

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -406,7 +406,7 @@ void vShutdown(ULONG thread_input) {
                                 || hv_c || hvd_gpio || imd_gpio || ckpt_gpio
                                 || inertia_sw_gpio || tsms_gpio;
 
-        if (shutdown_active || (get_shutdown() == true)) { // if tsms is still on when shutdown is active, trigger fault
+        if (shutdown_active || (is_shutdown_active() == true)) { // if tsms is still on when shutdown is active, trigger fault
             queue_send(&faults, &(fault_t){SHUTDOWN_FAULT}, TX_NO_WAIT);
         }
 


### PR DESCRIPTION
This PR disables RTDS if BMS indicates a shutdown. The PR also sends the shutdown fault if either BMS indicates a shutdown or VCU itself indicates a shutdown.

More context:
The BMS sends a message to VCU indicating if shutdown is active or not. If the message contains `true`, shutdown is active (which is bad). If the message contains `false`, shutdown is not active (which indicates normal operation).