### PR TITLE
Shutdown State Tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
     "./Core/Src/u_buttons.c"
     "./Core/Src/u_lightning.c"
     "./Core/Src/u_debug.c"
+    "./Core/Src/u_shutdown.c"
     "./Core/Src/u_ethernet.c"
     "./Core/Src/u_tc.c"
     "./Core/Src/u_traceout_app.c"

--- a/Core/Inc/u_shutdown.h
+++ b/Core/Inc/u_shutdown.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdbool.h>
+
+/**
+ * @brief  Updates the BMS shutdown state. Should only be called upon receiving the BMS shutdown state message.
+ * @param new_state The new state, as reported by the incoming message from BMS.
+ */
+void update_bms_shutdown(bool new_state);
+
+/**
+ * @brief  Processes shutdown telemetry and lightning fault. Meant to be called by the shutdown thread.
+ */
+void shutdown_process(void);
+
+/**
+ * @brief  Indicates if shutdown is active or not.
+ * @return The current shutdown state. `false` means that shutdown is NOT active, indicating normal operation. `true` means that shutdown IS active, which is bad.
+ */
+bool is_shutdown_active(void);

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -233,7 +233,7 @@ void can_inbox(can_msg_t *message) {
     case CANID_SHUTDOWN:
         shutdown_as_read_by_bms_t bms = { 0 };
         receive_shutdown_as_read_by_bms(message, &bms);
-        update_shutdown(bms.shutdown);
+        update_bms_shutdown(bms.shutdown);
 
         /* If shutdown is active, cancel the RTDS sound if it's active. */
         if(bms.shutdown == true) {

--- a/Core/Src/u_can.c
+++ b/Core/Src/u_can.c
@@ -10,6 +10,7 @@
 #include "u_statemachine.h"
 #include "u_dti.h"
 #include "u_efuses.h"
+#include "u_shutdown.h"
 #include "can_messages_tx.h"
 #include "can_messages_rx.h"
 

--- a/Core/Src/u_rtds.c
+++ b/Core/Src/u_rtds.c
@@ -6,6 +6,7 @@
 #include "u_statemachine.h"
 #include "u_faults.h"
 #include "u_tx_debug.h"
+#include "u_shutdown.h"
 
 /* Timer for RTDS. */
 static void _timer_callback(ULONG args); // Forward declaration for callback function.

--- a/Core/Src/u_shutdown.c
+++ b/Core/Src/u_shutdown.c
@@ -7,6 +7,7 @@
 #include "u_faults.h"
 #include "u_lightning.h"
 #include "debounce.h"
+#include "can_messages_tx.h"
 
 /* Bool to track the BMS shutdown state. */
 static _Atomic bool bms_shutdown = false;

--- a/Core/Src/u_shutdown.c
+++ b/Core/Src/u_shutdown.c
@@ -15,14 +15,6 @@ static _Atomic bool bms_shutdown = false;
 // When this bool is `false`, BMS is indicating that shutdown is NOT active, meaning that we are in normal operation and everything is good.
 // When this bool is `true`, BMS is indicating that shutdown IS active, which is bad.get_shutdown
 
-/* Bool the track the VCU shutdown state. */
-static _Atomic bool vcu_shutdown = false;
-// This is the shutdown state reported by VCU's own pins. It's updated periodically by the shutdown thread, in shutdown_process().shutdown.h
-// Just like BMS, when this bool is `false`, VCU's pins are indicating that shutdown is NOT active (meaning normal operation), while `true` indicates that shutdown IS active (not good).
-// It should usually by consistent with the BMS shutdown state, but there are certain shutdown pins that are only sent to BMS.
-// So, this state should always be used IN COMBINATION with the BMS shutdown state when determining if shutdown is active.
-// I.e., the true shutdown state is (bms_shutdown || vcu_shutdown).
-
 // callback for when either bms or imd indicates a fault - sets flag via arg
 static void _lightning_board_status_callback(void *arg) {
     *(bool *)arg = true;
@@ -35,7 +27,7 @@ void update_bms_shutdown(bool new_state) {
 
 /* Indicates if shutdown is active. */
 bool is_shutdown_active(void) {
-    return bms_shutdown || vcu_shutdown;
+    return bms_shutdown;
 }
 
 /* Processes shutdown telemetry and lightning fault. Meant to be called by the shutdown thread. */
@@ -69,23 +61,6 @@ void shutdown_process(void) {
         tsms_gpio,
         0
     );
-
-    /* If any of the pins AREN'T high, that means shutdown is active. */
-    vcu_shutdown = !bms_gpio || !bots_gpio || !spare_gpio || !bspd_gpio || !hv_c || !hvd_gpio || !imd_gpio || !ckpt_gpio || !inertia_sw_gpio || !tsms_gpio;
-
-    /* Lightning status with debounce. */
-    bool lightning_fault = !bms_gpio || !imd_gpio;
-
-    // Always call debounce so the cancel path runs when the fault clears.
-    // The callback sets lightning_is_red=true via arg; we track it separately
-    // so RED is sent every loop iteration (not just once per debounce cycle).
-    debounce(lightning_fault, &lightning_status_timer, LIGHTNING_BOARD_DEBOUNCE, &_lightning_board_status_callback, &lightning_is_red);
-    if (!lightning_fault) {
-        lightning_is_red = false;
-        send_lightning_board_status(LIGHT_GREEN);
-    } else if (lightning_is_red) {
-        send_lightning_board_status(LIGHT_RED);
-    }
 
     /* Check if shutdown is active. If it is, trigger the fault. */
     if (is_shutdown_active()) { // if tsms is still on when shutdown is active, trigger fault

--- a/Core/Src/u_shutdown.c
+++ b/Core/Src/u_shutdown.c
@@ -1,0 +1,92 @@
+#include "u_shutdown.h"
+#include <stdatomic.h>
+#include "timer.h"
+#include "u_tx_queues.h"
+#include "u_queues.h"
+#include "main.h"
+#include "u_faults.h"
+#include "u_lightning.h"
+
+/* Bool to track the BMS shutdown state. */
+static _Atomic bool bms_shutdown = false;
+// BMS periodically sends out a CAN message reporting the shutdown state. That state is tracked here.
+// When this bool is `false`, BMS is indicating that shutdown is NOT active, meaning that we are in normal operation and everything is good.
+// When this bool is `true`, BMS is indicating that shutdown IS active, which is bad.get_shutdown
+
+/* Bool the track the VCU shutdown state. */
+static _Atomic bool vcu_shutdown = false;
+// This is the shutdown state reported by VCU's own pins. It's updated periodically by the shutdown thread, in shutdown_process().shutdown.h
+// Just like BMS, when this bool is `false`, VCU's pins are indicating that shutdown is NOT active (meaning normal operation), while `true` indicates that shutdown IS active (not good).
+// It should usually by consistent with the BMS shutdown state, but there are certain shutdown pins that are only sent to BMS.
+// So, this state should always be used IN COMBINATION with the BMS shutdown state when determining if shutdown is active.
+// I.e., the true shutdown state is (bms_shutdown || vcu_shutdown).
+
+// callback for when either bms or imd indicates a fault - sets flag via arg
+static void _lightning_board_status_callback(void *arg) {
+    *(bool *)arg = true;
+}
+
+/* Updates the BMS shutdown state. Should only be called upon receiving the BMS shutdown state message. */
+void update_bms_shutdown(bool new_state) {
+    bms_shutdown = new_state;
+}
+
+/* Indicates if shutdown is active. */
+bool is_shutdown_active(void) {
+    return bms_shutdown || vcu_shutdown;
+}
+
+/* Processes shutdown telemetry and lightning fault. Meant to be called by the shutdown thread. */
+static nertimer_t lightning_status_timer;
+static bool lightning_is_red = false;
+#define LIGHTNING_BOARD_DEBOUNCE 500
+void shutdown_process(void) {
+    /* Read all of the shutdown pins. */
+    bool bms_gpio = (HAL_GPIO_ReadPin(BMS_GPIO_GPIO_Port, BMS_GPIO_Pin) == GPIO_PIN_SET);
+    bool bots_gpio = (HAL_GPIO_ReadPin(BOTS_GPIO_GPIO_Port, BOTS_GPIO_Pin) == GPIO_PIN_SET);
+    bool spare_gpio = (HAL_GPIO_ReadPin(SPARE_GPIO_GPIO_Port, SPARE_GPIO_Pin) == GPIO_PIN_SET);
+    bool bspd_gpio = (HAL_GPIO_ReadPin(BSPD_GPIO_GPIO_Port, BSPD_GPIO_Pin) == GPIO_PIN_SET);
+    bool hv_c = (HAL_GPIO_ReadPin(HV_C_GPIO_GPIO_Port, HV_C_GPIO_Pin) == GPIO_PIN_SET);
+    bool hvd_gpio = (HAL_GPIO_ReadPin(HVD_GPIO_GPIO_Port, HVD_GPIO_Pin) == GPIO_PIN_SET);
+    bool imd_gpio = (HAL_GPIO_ReadPin(IMD_GPIO_GPIO_Port, IMD_GPIO_Pin) == GPIO_PIN_SET);
+    bool ckpt_gpio = (HAL_GPIO_ReadPin(CKPT_GPIO_GPIO_Port, CKPT_GPIO_Pin) == GPIO_PIN_SET);
+    bool inertia_sw_gpio = (HAL_GPIO_ReadPin(INERTIA_SW_GPIO_GPIO_Port, INERTIA_SW_GPIO_Pin) == GPIO_PIN_SET);
+    bool tsms_gpio = (HAL_GPIO_ReadPin(TSMS_GPIO_GPIO_Port, TSMS_GPIO_Pin) == GPIO_PIN_SET);
+
+    /* Send Shutdown Pins CAN message. */
+    send_shutdown_pins(
+        bms_gpio,
+        bots_gpio,
+        spare_gpio,
+        bspd_gpio,
+        hv_c,
+        hvd_gpio,
+        imd_gpio,
+        ckpt_gpio,
+        inertia_sw_gpio,
+        tsms_gpio,
+        0
+    );
+
+    /* If any of the pins AREN'T high, that means shutdown is active. */
+    vcu_shutdown = !bms_gpio || !bots_gpio || !spare_gpio || !bspd_gpio || !hv_c || !hvd_gpio || !imd_gpio || !ckpt_gpio || !inertia_sw_gpio || !tsms_gpio;
+
+    /* Lightning status with debounce. */
+    bool lightning_fault = !bms_gpio || !imd_gpio;
+
+    // Always call debounce so the cancel path runs when the fault clears.
+    // The callback sets lightning_is_red=true via arg; we track it separately
+    // so RED is sent every loop iteration (not just once per debounce cycle).
+    debounce(lightning_fault, &lightning_status_timer, LIGHTNING_BOARD_DEBOUNCE, &_lightning_board_status_callback, &lightning_is_red);
+    if (!lightning_fault) {
+        lightning_is_red = false;
+        send_lightning_board_status(LIGHT_GREEN);
+    } else if (lightning_is_red) {
+        send_lightning_board_status(LIGHT_RED);
+    }
+
+    /* Check if shutdown is active. If it is, trigger the fault. */
+    if (is_shutdown_active()) { // if tsms is still on when shutdown is active, trigger fault
+        queue_send(&faults, &(fault_t){SHUTDOWN_FAULT}, TX_NO_WAIT);
+    }
+}

--- a/Core/Src/u_shutdown.c
+++ b/Core/Src/u_shutdown.c
@@ -6,6 +6,7 @@
 #include "main.h"
 #include "u_faults.h"
 #include "u_lightning.h"
+#include "debounce.h"
 
 /* Bool to track the BMS shutdown state. */
 static _Atomic bool bms_shutdown = false;

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -32,7 +32,6 @@
 static state_t cerberus_state;
 static bool is_ts_rising = false;
 static bool enter_drive_enabled = false;
-static _Atomic bool shutdown = false;
 
 /* Rising TS Callback and Timer */
 static void _rising_ts_cb(ULONG input) {

--- a/Core/Src/u_statemachine.c
+++ b/Core/Src/u_statemachine.c
@@ -19,6 +19,7 @@
 #include "u_pedals.h"
 #include "u_tc.h"
 #include "serial.h"
+#include "u_shutdown.h"
 
 #define STATE_TRANS_QUEUE_SIZE 4
 
@@ -62,14 +63,6 @@ void send_carstate_msg(void)
 		cerberus_state.functional,
 		tc_isEnabled()
 	);
-}
-
-void update_shutdown(bool new_shutdown) {
-	shutdown = new_shutdown;
-}
-
-bool is_shutdown_active(void) {
-	return shutdown;
 }
 
 int init_statemachine(void) {

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -21,6 +21,7 @@
 #include "u_lightning.h"
 #include "u_rtds.h"
 #include "u_nx_debug.h"
+#include "u_shutdown.h"
 #include "timer.h"
 #include "debounce.h"
 #include "u_traceout_app.h"
@@ -43,13 +44,6 @@
 #define PRIO_vRTDS             3
 #define PRIO_vTest             3
 #define PRIO_vPeripherals      3
-
-
-
-// callback for when either bms or imd indicates a fault - sets flag via arg
-static void _lightning_board_status_callback(void *arg) {
-    *(bool *)arg = true;
-}
 
 /* Test Thread */
 static thread_t test_thread = {
@@ -350,9 +344,7 @@ static thread_t shutdown_thread = {
         .auto_start = TX_AUTO_START,      /* Auto Start */
         .sleep      = 500,                /* Sleep (in ticks) */
         .function   = vShutdown           /* Thread Function */
-    };
-
-#define LIGHTNING_BOARD_DEBOUNCE 500
+};
 
 void vShutdown(ULONG thread_input) {
     /* Debounce Timer */
@@ -361,54 +353,8 @@ void vShutdown(ULONG thread_input) {
 
     while(1) {
 
-        bool bms_gpio = (HAL_GPIO_ReadPin(BMS_GPIO_GPIO_Port, BMS_GPIO_Pin) == GPIO_PIN_SET);
-        bool bots_gpio = (HAL_GPIO_ReadPin(BOTS_GPIO_GPIO_Port, BOTS_GPIO_Pin) == GPIO_PIN_SET);
-        bool spare_gpio = (HAL_GPIO_ReadPin(SPARE_GPIO_GPIO_Port, SPARE_GPIO_Pin) == GPIO_PIN_SET);
-        bool bspd_gpio = (HAL_GPIO_ReadPin(BSPD_GPIO_GPIO_Port, BSPD_GPIO_Pin) == GPIO_PIN_SET);
-        bool hv_c = (HAL_GPIO_ReadPin(HV_C_GPIO_GPIO_Port, HV_C_GPIO_Pin) == GPIO_PIN_SET);
-        bool hvd_gpio = (HAL_GPIO_ReadPin(HVD_GPIO_GPIO_Port, HVD_GPIO_Pin) == GPIO_PIN_SET);
-        bool imd_gpio = (HAL_GPIO_ReadPin(IMD_GPIO_GPIO_Port, IMD_GPIO_Pin) == GPIO_PIN_SET);
-        bool ckpt_gpio = (HAL_GPIO_ReadPin(CKPT_GPIO_GPIO_Port, CKPT_GPIO_Pin) == GPIO_PIN_SET);
-        bool inertia_sw_gpio = (HAL_GPIO_ReadPin(INERTIA_SW_GPIO_GPIO_Port, INERTIA_SW_GPIO_Pin) == GPIO_PIN_SET);
-        bool tsms_gpio = (HAL_GPIO_ReadPin(TSMS_GPIO_GPIO_Port, TSMS_GPIO_Pin) == GPIO_PIN_SET);
-
-
-        //lightning status with debounce
-        bool lightning_fault = bms_gpio || imd_gpio;
-
-        // Always call debounce so the cancel path runs when the fault clears.
-        // The callback sets lightning_is_red=true via arg; we track it separately
-        // so RED is sent every loop iteration (not just once per debounce cycle).
-        debounce(lightning_fault, &lightning_status_timer, LIGHTNING_BOARD_DEBOUNCE, &_lightning_board_status_callback, &lightning_is_red);
-        if (!lightning_fault) {
-            lightning_is_red = false;
-            send_lightning_board_status(LIGHT_GREEN);
-        } else if (lightning_is_red) {
-            send_lightning_board_status(LIGHT_RED);
-        }
-
-        /* Send Shutdown Pins CAN message. */
-        send_shutdown_pins(
-            bms_gpio,
-            bots_gpio,
-            spare_gpio,
-            bspd_gpio,
-            hv_c,
-            hvd_gpio,
-            imd_gpio,
-            ckpt_gpio,
-            inertia_sw_gpio,
-            tsms_gpio,
-            0
-        );
-
-        bool shutdown_active = bms_gpio || bots_gpio || spare_gpio || bspd_gpio
-                                || hv_c || hvd_gpio || imd_gpio || ckpt_gpio
-                                || inertia_sw_gpio || tsms_gpio;
-
-        if (shutdown_active || (is_shutdown_active() == true)) { // if tsms is still on when shutdown is active, trigger fault
-            queue_send(&faults, &(fault_t){SHUTDOWN_FAULT}, TX_NO_WAIT);
-        }
+        /* Process shutdown. */
+        shutdown_process();
 
         /* Sleep Thread for specified number of ticks. */
         tx_thread_sleep(shutdown_thread.sleep);

--- a/Core/Src/u_threads.c
+++ b/Core/Src/u_threads.c
@@ -342,15 +342,11 @@ static thread_t shutdown_thread = {
         .threshold  = 0,                  /* Preemption Threshold */
         .time_slice = TX_NO_TIME_SLICE,   /* Time Slice */
         .auto_start = TX_AUTO_START,      /* Auto Start */
-        .sleep      = 500,                /* Sleep (in ticks) */
+        .sleep      = 100,                /* Sleep (in ticks) */
         .function   = vShutdown           /* Thread Function */
 };
 
 void vShutdown(ULONG thread_input) {
-    /* Debounce Timer */
-    static nertimer_t lightning_status_timer;
-    static bool lightning_is_red = false;
-
     while(1) {
 
         /* Process shutdown. */


### PR DESCRIPTION
Created a new `u_shutdown.c` file to centralize the shutdown state tracking. Right now, VCU tracks shutdown from it's own pins, as well as from BMS (via a CAN message BMS periodically sends out). The "official" shutdown state is therefore `vcu_shutdown || bms_shutdown` (i.e., if either system thinks shutdown is active).