### PR TITLE
Added Separate PSI Telemetry for Brakes

### DIFF
--- a/Core/Inc/can_messages_tx.h
+++ b/Core/Inc/can_messages_tx.h
@@ -197,10 +197,11 @@ uint8_t send_car_state
 * Contents of this message:
 * VCU/Pedals/Percentages/acceleration_pedal - How far the acceleration pedal is pressed, ranging from 0 to 1.
 * VCU/Pedals/Percentages/brake_pedal - How far the brake pedal is pressed, ranging from 0 to 1.
-* VCU/Pedals/brake_psi - Brake Pedal, as PSI
+* VCU/Pedals/PSI/Brake_Front - Front Brake Sensor (BRAKE1) as PSI.
+* VCU/Pedals/PSI/Brake_Back - Back Brake Sensor (BRAKE2) as PSI.
 */
 uint8_t send_pedal_percent_pressed_values
-(float accel_norm,float brake_norm,float brake_psi);
+(float accel_norm,float brake_norm,float brake_psi_brake1,float brake_psi_brake2);
 
 /**
 * Contents of this message:

--- a/Core/Src/can_messages_tx.c
+++ b/Core/Src/can_messages_tx.c
@@ -694,7 +694,7 @@ uint8_t send_car_state
 }
 
 uint8_t send_pedal_percent_pressed_values
-(float accel_norm,float brake_norm,float brake_psi)
+(float accel_norm,float brake_norm,float brake_psi_brake1,float brake_psi_brake2)
 {
     can_msg_t msg;
     msg.id = 0x505;
@@ -712,11 +712,17 @@ uint8_t send_pedal_percent_pressed_values
                         }
                         data |= ((brake_norm_i) & 0xFFFFULL) << 32;
             
-                        int32_t brake_psi_i = (int32_t)(brake_psi*10);
-                        if(brake_psi_i > 32767) {brake_psi_i = 32767;
-                        } else if(brake_psi_i < -32768) {brake_psi_i = -32768;
+                        int32_t brake_psi_brake1_i = (int32_t)(brake_psi_brake1*10);
+                        if(brake_psi_brake1_i > 32767) {brake_psi_brake1_i = 32767;
+                        } else if(brake_psi_brake1_i < -32768) {brake_psi_brake1_i = -32768;
                         }
-                        data |= ((uint32_t)(brake_psi_i) & 0xFFFFULL) << 16;
+                        data |= ((uint32_t)(brake_psi_brake1_i) & 0xFFFFULL) << 16;
+            
+                        int32_t brake_psi_brake2_i = (int32_t)(brake_psi_brake2*10);
+                        if(brake_psi_brake2_i > 32767) {brake_psi_brake2_i = 32767;
+                        } else if(brake_psi_brake2_i < -32768) {brake_psi_brake2_i = -32768;
+                        }
+                        data |= ((uint32_t)(brake_psi_brake2_i) & 0xFFFFULL) << 0;
             
             uint64_t data_bigendian = __builtin_bswap64(data);
             memcpy(msg.data, &data_bigendian, 8);

--- a/Core/Src/u_pedals.c
+++ b/Core/Src/u_pedals.c
@@ -45,7 +45,8 @@ typedef struct {
 	float voltage_brake2;
 	float percentage_accel;
 	float percentage_brake;
-	float psi_brake;
+	float psi_brake1;
+	float psi_brake2;
 } pedal_data_t;
 static pedal_data_t pedal_data = { 0 };
 
@@ -153,7 +154,8 @@ static void _send_pedal_data(ULONG args) {
 	send_pedal_percent_pressed_values(
 		pedal_data.percentage_accel,
 		pedal_data.percentage_brake,
-		pedal_data.psi_brake
+		pedal_data.psi_brake1,
+		pedal_data.psi_brake2
 	);
 
 	/* Send drive lock state info. */
@@ -646,8 +648,9 @@ void pedals_process(void) {
     _calculate_brake_faults(pedal_data.voltage_brake1, pedal_data.voltage_brake2); // Check for faults.
 
 	/* Calculate brake in PSI. */
-	float avg_brake_voltage = (pedal_data.voltage_brake1 + pedal_data.voltage_brake2) / 2;
-	pedal_data.psi_brake = (1250*avg_brake_voltage)-625; // // scaling function: f(x) = 1,250x - 625
+	pedal_data.psi_brake1 = (1250*pedal_data.psi_brake1)-625;
+	pedal_data.psi_brake2 = (1250*pedal_data.psi_brake2)-625;
+	// scaling function: f(x) = 1,250x - 625
 
     /* Set brake state, and turn brakelight on/off. */
     if(pedal_data.percentage_brake > PEDAL_BRAKE_THRESH) {

--- a/Core/Src/u_pedals.c
+++ b/Core/Src/u_pedals.c
@@ -648,9 +648,9 @@ void pedals_process(void) {
     _calculate_brake_faults(pedal_data.voltage_brake1, pedal_data.voltage_brake2); // Check for faults.
 
 	/* Calculate brake in PSI. */
-	pedal_data.psi_brake1 = (1250*pedal_data.psi_brake1)-625;
-	pedal_data.psi_brake2 = (1250*pedal_data.psi_brake2)-625;
-	// scaling function: f(x) = 1,250x - 625
+	pedal_data.psi_brake1 = (1250*pedal_data.voltage_brake1)-625;
+	pedal_data.psi_brake2 = (1250*pedal_data.voltage_brake2)-625;
+	// scaling function: f(x) = 1,250x - 625, where f(x) is PSI and x is voltage.
 
     /* Set brake state, and turn brakelight on/off. */
     if(pedal_data.percentage_brake > PEDAL_BRAKE_THRESH) {

--- a/Core/Src/u_pedals.c
+++ b/Core/Src/u_pedals.c
@@ -648,8 +648,8 @@ void pedals_process(void) {
     _calculate_brake_faults(pedal_data.voltage_brake1, pedal_data.voltage_brake2); // Check for faults.
 
 	/* Calculate brake in PSI. */
-	pedal_data.psi_brake1 = (1250*pedal_data.voltage_brake1)-625;
-	pedal_data.psi_brake2 = (1250*pedal_data.voltage_brake2)-625;
+	pedal_data.psi_brake1 = (1250.0f*pedal_data.voltage_brake1)-625.0f;
+	pedal_data.psi_brake2 = (1250.0f*pedal_data.voltage_brake2)-625.0f;
 	// scaling function: f(x) = 1,250x - 625, where f(x) is PSI and x is voltage.
 
     /* Set brake state, and turn brakelight on/off. */


### PR DESCRIPTION
This PR makes it so brake PSI values are reported separately for BRAKE1 (front) and BRAKE2 (back). Previously, we were just sending out an average between the two brakes.